### PR TITLE
Parameterize docker variables

### DIFF
--- a/rp-smartnode-install/network/pyrmont/config.yml
+++ b/rp-smartnode-install/network/pyrmont/config.yml
@@ -1,12 +1,16 @@
 rocketpool:
   storageAddress: 0xA85A8022E8F28E49B8BBfb792f93ee914B342C3b
 smartnode:
+  projectName: rocketpool
+  networkName: rocketpool_net
+  image: rocketpool/smartnode:v0.0.8
   passwordPath: /.rocketpool/data/password
   walletPath: /.rocketpool/data/wallet
   validatorKeychainPath: /.rocketpool/data/validators
 chains:
   eth1:
     provider: http://eth1:8545
+    volumeName: rocketpool_eth1clientdata
     client:
       options:
       - id: geth
@@ -43,6 +47,7 @@ chains:
           required: true
   eth2:
     provider: eth2:5052
+    volumeName: rocketpool_eth2clientdata
     client:
       options:
       - id: lighthouse

--- a/rp-smartnode-install/network/pyrmont/docker-compose.yml
+++ b/rp-smartnode-install/network/pyrmont/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.8"
 services:
   eth1:
     image: ${ETH1_IMAGE}
-    container_name: rocketpool_eth1
+    container_name: ${COMPOSE_PROJECT_NAME}_eth1
     restart: unless-stopped
     ports:
       - "30303:30303/udp"
@@ -22,7 +22,7 @@ services:
     command: "/setup/start-node.sh"
   eth2:
     image: ${ETH2_IMAGE}
-    container_name: rocketpool_eth2
+    container_name: ${COMPOSE_PROJECT_NAME}_eth2
     restart: unless-stopped
     ports:
       - "9001:9001/tcp"
@@ -41,7 +41,7 @@ services:
       - eth1
   validator:
     image: ${VALIDATOR_IMAGE}
-    container_name: rocketpool_validator
+    container_name: ${COMPOSE_PROJECT_NAME}_validator
     restart: unless-stopped
     volumes:
       - ./data:/data
@@ -57,8 +57,8 @@ services:
     depends_on:
       - eth2
   api:
-    image: rocketpool/smartnode:v0.0.8
-    container_name: rocketpool_api
+    image: ${SMARTNODE_IMAGE}
+    container_name: ${COMPOSE_PROJECT_NAME}_api
     restart: unless-stopped
     volumes:
       - .:/.rocketpool
@@ -69,8 +69,8 @@ services:
     entrypoint: /bin/sleep
     command: "infinity"
   node:
-    image: rocketpool/smartnode:v0.0.8
-    container_name: rocketpool_node
+    image: ${SMARTNODE_IMAGE}
+    container_name: ${COMPOSE_PROJECT_NAME}_node
     restart: unless-stopped
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
@@ -82,8 +82,8 @@ services:
       - eth1
       - eth2
   watchtower:
-    image: rocketpool/smartnode:v0.0.8
-    container_name: rocketpool_watchtower
+    image: ${SMARTNODE_IMAGE}
+    container_name: ${COMPOSE_PROJECT_NAME}_watchtower
     restart: unless-stopped
     volumes:
       - .:/.rocketpool
@@ -95,6 +95,9 @@ services:
       - eth2
 networks:
   net:
+    name: ${NETWORK_NAME}
 volumes:
   eth1clientdata:
+    name: ${ETH1_VOLUME_NAME}
   eth2clientdata:
+    name: ${ETH2_VOLUME_NAME}


### PR DESCRIPTION
Configuration changes to go with the smartnode commit https://github.com/rocket-pool/smartnode/pull/74
The following parameters and values are added to `config.yml` and can be overridden by `settings.yml`:
```
smartnode:
  projectName: rocketpool
  networkName: rocketpool_net
  image: rocketpool/smartnode:v0.0.8
chains:
  eth1:
    volumeName: rocketpool_eth1clientdata
  eth2:
    volumeName: rocketpool_eth2clientdata
```
These parameters correspond to substitutions made for environment variables in `docker-compose.yml`.  For the current set of parameter values, it results in the same docker compose file as is currently defined but allows for easier overriding of variables when defining multiple rocketpool nodes are run on the same host machine.