### PR TITLE
shutdown gracefully using trap SIGTERM

### DIFF
--- a/rp-smartnode-install/network/pyrmont/chains/eth1/start-node.sh
+++ b/rp-smartnode-install/network/pyrmont/chains/eth1/start-node.sh
@@ -2,16 +2,46 @@
 # This script launches ETH1 clients for Rocket Pool's docker stack; only edit if you know what you're doing ;)
 
 
+prep_term()
+{
+    unset term_child_pid
+    unset term_kill_needed
+    trap 'handle_term' TERM INT
+}
+
+handle_term()
+{
+    if [ "${term_child_pid}" ]; then
+        kill -TERM "${term_child_pid}" 2>/dev/null
+    else
+        term_kill_needed="yes"
+    fi
+}
+
+wait_term()
+{
+    term_child_pid=$!
+    if [ "${term_kill_needed}" ]; then
+        kill -TERM "${term_child_pid}" 2>/dev/null 
+    fi
+    wait ${term_child_pid} 2>/dev/null
+    trap - TERM INT
+    wait ${term_child_pid} 2>/dev/null
+}
+
+
 # Geth startup
 if [ "$CLIENT" = "geth" ]; then
 
-    CMD="/usr/local/bin/geth --goerli --datadir /ethclient/geth --http --http.addr 0.0.0.0 --http.port 8545 --http.api eth,net,personal,web3 --http.vhosts '*'"
+    CMD="exec /usr/local/bin/geth --goerli --datadir /ethclient/geth --http --http.addr 0.0.0.0 --http.port 8545 --http.api eth,net,personal,web3 --http.vhosts '*'"
 
     if [ ! -z "$ETHSTATS_LABEL" ] && [ ! -z "$ETHSTATS_LOGIN" ]; then
         CMD="$CMD --ethstats $ETHSTATS_LABEL:$ETHSTATS_LOGIN"
     fi
 
-    eval "$CMD"
+    prep_term
+    eval "$CMD" &
+    wait_term
 
 fi
 
@@ -19,7 +49,7 @@ fi
 # Infura startup
 if [ "$CLIENT" = "infura" ]; then
 
-    /go/bin/rocketpool-pow-proxy --port 8545 --network goerli --projectId $INFURA_PROJECT_ID
+    exec /go/bin/rocketpool-pow-proxy --port 8545 --network goerli --projectId $INFURA_PROJECT_ID
 
 fi
 
@@ -27,7 +57,7 @@ fi
 # Custom provider startup
 if [ "$CLIENT" = "custom" ]; then
 
-    /go/bin/rocketpool-pow-proxy --port 8545 --providerUrl $PROVIDER_URL
+    exec /go/bin/rocketpool-pow-proxy --port 8545 --providerUrl $PROVIDER_URL
 
 fi
 

--- a/rp-smartnode-install/network/pyrmont/chains/eth2/start-beacon.sh
+++ b/rp-smartnode-install/network/pyrmont/chains/eth2/start-beacon.sh
@@ -5,7 +5,7 @@
 # Lighthouse startup
 if [ "$CLIENT" = "lighthouse" ]; then
 
-    /usr/local/bin/lighthouse beacon --network pyrmont --datadir /ethclient/lighthouse --port 9001 --discovery-port 9001 --eth1 --eth1-endpoint "$ETH1_PROVIDER" --http --http-address 0.0.0.0 --http-port 5052
+    exec /usr/local/bin/lighthouse beacon --network pyrmont --datadir /ethclient/lighthouse --port 9001 --discovery-port 9001 --eth1 --eth1-endpoint "$ETH1_PROVIDER" --http --http-address 0.0.0.0 --http-port 5052
 
 fi
 
@@ -13,7 +13,7 @@ fi
 # Prysm startup
 if [ "$CLIENT" = "prysm" ]; then
 
-    /app/beacon-chain/beacon-chain --accept-terms-of-use --pyrmont --datadir /ethclient/prysm --p2p-tcp-port 9001 --p2p-udp-port 9001 --http-web3provider "$ETH1_PROVIDER" --rpc-host 0.0.0.0 --rpc-port 5052
+    exec /app/beacon-chain/beacon-chain --accept-terms-of-use --pyrmont --datadir /ethclient/prysm --p2p-tcp-port 9001 --p2p-udp-port 9001 --http-web3provider "$ETH1_PROVIDER" --rpc-host 0.0.0.0 --rpc-port 5052
 
 fi
 

--- a/rp-smartnode-install/network/pyrmont/chains/eth2/start-validator.sh
+++ b/rp-smartnode-install/network/pyrmont/chains/eth2/start-validator.sh
@@ -16,7 +16,7 @@ fi
 # Lighthouse startup
 if [ "$CLIENT" = "lighthouse" ]; then
 
-    /usr/local/bin/lighthouse validator --network pyrmont --datadir /data/validators/lighthouse --init-slashing-protection --beacon-node "http://$ETH2_PROVIDER" --graffiti "$GRAFFITI"
+    exec /usr/local/bin/lighthouse validator --network pyrmont --datadir /data/validators/lighthouse --init-slashing-protection --beacon-node "http://$ETH2_PROVIDER" --graffiti "$GRAFFITI"
 
 fi
 
@@ -24,7 +24,7 @@ fi
 # Prysm startup
 if [ "$CLIENT" = "prysm" ]; then
 
-    /app/validator/validator --accept-terms-of-use --pyrmont --wallet-dir /data/validators/prysm-non-hd --wallet-password-file /data/password --beacon-rpc-provider "$ETH2_PROVIDER" --graffiti "$GRAFFITI"
+    exec /app/validator/validator --accept-terms-of-use --pyrmont --wallet-dir /data/validators/prysm-non-hd --wallet-password-file /data/password --beacon-rpc-provider "$ETH2_PROVIDER" --graffiti "$GRAFFITI"
 
 fi
 

--- a/rp-smartnode-install/network/pyrmont/docker-compose.yml
+++ b/rp-smartnode-install/network/pyrmont/docker-compose.yml
@@ -4,6 +4,7 @@ services:
     image: ${ETH1_IMAGE}
     container_name: ${COMPOSE_PROJECT_NAME}_eth1
     restart: unless-stopped
+    stop_grace_period: 1m
     ports:
       - "30303:30303/udp"
       - "30303:30303/tcp"
@@ -18,8 +19,7 @@ services:
       - ETHSTATS_LOGIN=${ETHSTATS_LOGIN}
       - INFURA_PROJECT_ID=${INFURA_PROJECT_ID}
       - PROVIDER_URL=${PROVIDER_URL}
-    entrypoint: sh
-    command: "/setup/start-node.sh"
+    entrypoint: "/setup/start-node.sh"
   eth2:
     image: ${ETH2_IMAGE}
     container_name: ${COMPOSE_PROJECT_NAME}_eth2
@@ -35,8 +35,7 @@ services:
     environment:
       - CLIENT=${ETH2_CLIENT}
       - ETH1_PROVIDER=${ETH1_PROVIDER}
-    entrypoint: sh
-    command: "/setup/start-beacon.sh"
+    entrypoint: "/setup/start-beacon.sh"
     depends_on:
       - eth1
   validator:
@@ -52,14 +51,15 @@ services:
       - CLIENT=${VALIDATOR_CLIENT}
       - ETH2_PROVIDER=${ETH2_PROVIDER}
       - CUSTOM_GRAFFITI=${CUSTOM_GRAFFITI}
-    entrypoint: sh
-    command: "/setup/start-validator.sh"
+    entrypoint: "/setup/start-validator.sh"
     depends_on:
       - eth2
   api:
     image: ${SMARTNODE_IMAGE}
     container_name: ${COMPOSE_PROJECT_NAME}_api
     restart: unless-stopped
+    stop_signal: SIGKILL
+    stop_grace_period: 1s
     volumes:
       - .:/.rocketpool
     networks:


### PR DESCRIPTION
fixes rocket-pool/smartnode-install#18
based on solutions given in https://unix.stackexchange.com/questions/146756/forward-sigterm-to-child-in-bash  
- use exec to execute and exit the shell where possible 
- but this doesn't work with the geth command because the quote characters do not get interpreted correctly