### PR TITLE
add per log request limit for beacon node to accommodate infura eth1

### DIFF
--- a/rp-smartnode-install/network/pyrmont/chains/eth2/start-beacon.sh
+++ b/rp-smartnode-install/network/pyrmont/chains/eth2/start-beacon.sh
@@ -5,7 +5,7 @@
 # Lighthouse startup
 if [ "$CLIENT" = "lighthouse" ]; then
 
-    /usr/local/bin/lighthouse beacon --network pyrmont --datadir /ethclient/lighthouse --port 9001 --discovery-port 9001 --eth1 --eth1-endpoint "$ETH1_PROVIDER" --http --http-address 0.0.0.0 --http-port 5052
+    /usr/local/bin/lighthouse beacon --network pyrmont --datadir /ethclient/lighthouse --port 9001 --discovery-port 9001 --eth1 --eth1-endpoint "$ETH1_PROVIDER" --http --http-address 0.0.0.0 --http-port 5052 --eth1-blocks-per-log-query 150
 
 fi
 
@@ -13,7 +13,7 @@ fi
 # Prysm startup
 if [ "$CLIENT" = "prysm" ]; then
 
-    /app/beacon-chain/beacon-chain --accept-terms-of-use --pyrmont --datadir /ethclient/prysm --p2p-tcp-port 9001 --p2p-udp-port 9001 --http-web3provider "$ETH1_PROVIDER" --rpc-host 0.0.0.0 --rpc-port 5052
+    /app/beacon-chain/beacon-chain --accept-terms-of-use --pyrmont --datadir /ethclient/prysm --p2p-tcp-port 9001 --p2p-udp-port 9001 --http-web3provider "$ETH1_PROVIDER" --rpc-host 0.0.0.0 --rpc-port 5052 --eth1-header-req-limit 150
 
 fi
 


### PR DESCRIPTION
Fixes rocket-pool/smartnode-install#20

Added parameters to the respective beacon node clients with request limit at 150 per block.  Testing on lighthouse and prysm connecting to infura, will post results when done.