### PR TITLE
use SIGKILL for sleep process (api container)

### DIFF
--- a/rp-smartnode-install/network/pyrmont/docker-compose.yml
+++ b/rp-smartnode-install/network/pyrmont/docker-compose.yml
@@ -63,6 +63,8 @@ services:
     image: ${SMARTNODE_IMAGE}
     container_name: ${COMPOSE_PROJECT_NAME}_api
     restart: unless-stopped
+    stop_signal: SIGKILL
+    stop_grace_period: 1s
     volumes:
       - .:/.rocketpool
     networks:


### PR DESCRIPTION
This was missed from the last pull request rocket-pool/smartnode-install#21
why SIGTERM doesn't work on sleep in docker is described here https://superuser.com/questions/1299461/how-can-i-stop-a-docker-container-running-sleep