### PR TITLE
Update Docker Image Versions

### DIFF
--- a/rp-smartnode-install/network/pyrmont/config.yml
+++ b/rp-smartnode-install/network/pyrmont/config.yml
@@ -64,7 +64,7 @@ chains:
           \t\talong with the Ethereum Foundation, Consensys, and private\n
           \t\tindividuals. Lighthouse is built in Rust and offered under an\n
           \t\tApache 2.0 License."
-        image: sigp/lighthouse:v1.2.0
+        image: sigp/lighthouse:v1.2.1
         link: https://lighthouse-book.sigmaprime.io/
         params:
         - name: Custom Graffiti

--- a/rp-smartnode-install/network/pyrmont/config.yml
+++ b/rp-smartnode-install/network/pyrmont/config.yml
@@ -109,7 +109,7 @@ chains:
           \t\tinteracting with the core Ethereum platform. Teku is Apache 2\n
           \t\tlicensed and written in Java, a language notable for its\n
           \t\tmaturity & ubiquity."
-        image: consensys/teku:21.2.0-jdk14 # JDK15 incompatible with ARM
+        image: consensys/teku:21.2.0
         link: https://docs.teku.consensys.net/en/stable/
         params:
         - name: Custom Graffiti


### PR DESCRIPTION
Teku:
We don't need to use JDK14 anymore because it no longer works on Pi - JDK15 (the default) is fine. Not that it mattered on x64 anyway, but it's nice to be consistent.

Lighthouse:
v1.2.0 has a bug where you can't exit a validator (https://github.com/sigp/lighthouse/pull/2257), v1.2.1 fixes it. Thanks to KingLee for pointing this out.