### PR TITLE
Update Graffiti to reflect the current version

### DIFF
--- a/rp-smartnode-install/network/pyrmont/chains/eth2/start-validator.sh
+++ b/rp-smartnode-install/network/pyrmont/chains/eth2/start-validator.sh
@@ -3,7 +3,7 @@
 
 
 # RP version number for graffiti
-ROCKET_POOL_VERSION="v1.0.0-b.0"
+ROCKET_POOL_VERSION="v1.0.0-b.2"
 
 
 # Get graffiti text

--- a/rp-smartnode-install/network/pyrmont/chains/eth2/start-validator.sh
+++ b/rp-smartnode-install/network/pyrmont/chains/eth2/start-validator.sh
@@ -3,7 +3,7 @@
 
 
 # RP version number for graffiti
-ROCKET_POOL_VERSION="v0.0.9"
+ROCKET_POOL_VERSION="v1.0.0-b.0"
 
 
 # Get graffiti text


### PR DESCRIPTION
The next release will most likely be v1.0.0-b.2 so I decided to use that version.

```
uses b instead of beta to stay under the 32 character limit.
Calculations are:
+  3 characters: Prefix "RP "
+ 10 characters: Version string "v1.0.0-b.2"
+  3 characters: Decorator when using a custom graffiti " ()"
+ 16 characters: Custom graffiti, which has a 16 character limit according to the config regex.
------
  32 characters in total
```