### PR TITLE
Added graffiti support to Nimbus

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -196,6 +196,7 @@ case "$PLATFORM" in
         echo "Automatic dependency installation for the $PLATFORM operating system is not supported."
         echo "Please install docker and docker-compose manually, then try again with the '-d' flag to skip OS dependency installation."
         echo "Be sure to add yourself to the docker group with 'sudo usermod -aG docker $USER' after installing docker."
+        echo "Log out and back in, or restart your system after you run this command."
         fail "Could not install OS dependencies."
     ;;
 

--- a/rp-smartnode-install/network/pyrmont/chains/eth2/start-beacon.sh
+++ b/rp-smartnode-install/network/pyrmont/chains/eth2/start-beacon.sh
@@ -2,6 +2,13 @@
 # This script launches ETH2 beacon clients for Rocket Pool's docker stack; only edit if you know what you're doing ;)
 
 
+# Get graffiti text
+GRAFFITI="RP $ROCKET_POOL_VERSION"
+if [ ! -z "$CUSTOM_GRAFFITI" ]; then
+    GRAFFITI="$GRAFFITI ($CUSTOM_GRAFFITI)"
+fi
+
+
 # Lighthouse startup
 if [ "$CLIENT" = "lighthouse" ]; then
 

--- a/rp-smartnode-install/network/pyrmont/chains/eth2/start-validator.sh
+++ b/rp-smartnode-install/network/pyrmont/chains/eth2/start-validator.sh
@@ -2,10 +2,6 @@
 # This script launches ETH2 validator clients for Rocket Pool's docker stack; only edit if you know what you're doing ;)
 
 
-# RP version number for graffiti; MAX 10 chars
-ROCKET_POOL_VERSION="v1.0.0-b.1"
-
-
 # Get graffiti text
 GRAFFITI="RP $ROCKET_POOL_VERSION"
 if [ ! -z "$CUSTOM_GRAFFITI" ]; then

--- a/rp-smartnode-install/network/pyrmont/config.yml
+++ b/rp-smartnode-install/network/pyrmont/config.yml
@@ -3,6 +3,7 @@ rocketpool:
   rplFaucetAddress: 0x6aC372F4bd37b9588D7eAb93A67E304421E26E48
 smartnode:
   projectName: rocketpool
+  graffitiVersion: v1.0.0-b.1
   image: rocketpool/smartnode:v1.0.0-beta.1
   passwordPath: /.rocketpool/data/password
   walletPath: /.rocketpool/data/wallet

--- a/rp-smartnode-install/network/pyrmont/docker-compose.yml
+++ b/rp-smartnode-install/network/pyrmont/docker-compose.yml
@@ -40,6 +40,8 @@ services:
       - CLIENT=${ETH2_CLIENT}
       - ETH1_PROVIDER=${ETH1_PROVIDER}
       - ETH1_WS_PROVIDER=${ETH1_WS_PROVIDER}
+      - CUSTOM_GRAFFITI=${CUSTOM_GRAFFITI}
+      - ROCKET_POOL_VERSION=${ROCKET_POOL_VERSION}
     entrypoint: sh
     command: "/setup/start-beacon.sh"
     depends_on:
@@ -59,6 +61,7 @@ services:
       - CLIENT=${VALIDATOR_CLIENT}
       - ETH2_PROVIDER=${ETH2_PROVIDER}
       - CUSTOM_GRAFFITI=${CUSTOM_GRAFFITI}
+      - ROCKET_POOL_VERSION=${ROCKET_POOL_VERSION}
     entrypoint: sh
     command: "/setup/start-validator.sh"
     depends_on:


### PR DESCRIPTION
In this PR, I move the `ROCKET_POOL_VERSION` env var out of `start-validators.sh` and make it a setting in `config.yml`. This should make it easier to update in the future. I also propagated it via docker-compose to `start-beacon.sh` so Nimbus can have access to it and `CUSTOM_GRAFFITI`, which lets it have graffiti support.

Minor add: I also added a string to the unsupported OS error text from `install.sh` that suggests the user relog / restart after giving themselves permissions to the `docker` group, so the setting takes effect.