### PR TITLE
Add More Settings to the Service Config Interview

### DIFF
--- a/rp-smartnode-install/network/pyrmont/chains/eth1/start-node.sh
+++ b/rp-smartnode-install/network/pyrmont/chains/eth1/start-node.sh
@@ -11,6 +11,18 @@ if [ "$CLIENT" = "geth" ]; then
         CMD="$CMD --ethstats $ETHSTATS_LABEL:$ETHSTATS_LOGIN"
     fi
 
+    if [ ! -z "$GETH_CACHE_SIZE" ]; then
+        CMD="$CMD --cache $GETH_CACHE_SIZE"
+    fi
+
+    if [ ! -z "$GETH_MAX_PEERS" ]; then
+        CMD="$CMD --maxpeers $GETH_MAX_PEERS"
+    fi
+
+    if [ ! -z "$ETH1_P2P_PORT" ]; then
+        CMD="$CMD --port $ETH1_P2P_PORT"
+    fi
+
     exec ${CMD} --http.vhosts '*'
 
 fi

--- a/rp-smartnode-install/network/pyrmont/chains/eth2/start-beacon.sh
+++ b/rp-smartnode-install/network/pyrmont/chains/eth2/start-beacon.sh
@@ -12,7 +12,7 @@ fi
 # Lighthouse startup
 if [ "$CLIENT" = "lighthouse" ]; then
 
-    CMD="/usr/local/bin/lighthouse beacon --network pyrmont --datadir /ethclient/lighthouse --port $ETH2_P2P_PORT --discovery-port $ETH2_P2P_PORT --eth1 --eth1-endpoints \"$ETH1_PROVIDER\" --http --http-address 0.0.0.0 --http-port 5052 --eth1-blocks-per-log-query 150 --disable-upnp"
+    CMD="/usr/local/bin/lighthouse beacon --network pyrmont --datadir /ethclient/lighthouse --port $ETH2_P2P_PORT --discovery-port $ETH2_P2P_PORT --eth1 --eth1-endpoints $ETH1_PROVIDER --http --http-address 0.0.0.0 --http-port 5052 --eth1-blocks-per-log-query 150 --disable-upnp"
 
     if [ ! -z "$ETH2_MAX_PEERS" ]; then
         CMD="$CMD --target-peers $ETH2_MAX_PEERS"
@@ -30,13 +30,14 @@ if [ "$CLIENT" = "nimbus" ]; then
     mkdir -p /data/validators/nimbus/validators
     mkdir -p /data/validators/nimbus/secrets
 
-    CMD="/home/user/nimbus-eth2/build/nimbus_beacon_node --non-interactive --enr-auto-update --network=pyrmont --data-dir=/ethclient/nimbus --tcp-port=$ETH2_P2P_PORT --udp-port=$ETH2_P2P_PORT --web3-url=\"$ETH1_WS_PROVIDER\" --rpc --rpc-address=0.0.0.0 --rpc-port=5052 --insecure-netkey-password=true --validators-dir=/data/validators/nimbus/validators --secrets-dir=/data/validators/nimbus/secrets --graffiti=\"$GRAFFITI\""
+    CMD="/home/user/nimbus-eth2/build/nimbus_beacon_node --non-interactive --enr-auto-update --network=pyrmont --data-dir=/ethclient/nimbus --log-file=/ethclient/nimbus/nbc_bn_$(date +%Y%m%d%H%M%S).log --tcp-port=$ETH2_P2P_PORT --udp-port=$ETH2_P2P_PORT --web3-url=$ETH1_WS_PROVIDER --rpc --rpc-address=0.0.0.0 --rpc-port=5052 --insecure-netkey-password=true --validators-dir=/data/validators/nimbus/validators --secrets-dir=/data/validators/nimbus/secrets"
 
     if [ ! -z "$ETH2_MAX_PEERS" ]; then
         CMD="$CMD --max-peers=$ETH2_MAX_PEERS"
     fi
 
-    exec ${CMD}
+    # Graffiti breaks if it's in the CMD string instead of here because of spaces
+    exec ${CMD} --graffiti="$GRAFFITI"
 
 fi
 
@@ -44,7 +45,7 @@ fi
 # Prysm startup
 if [ "$CLIENT" = "prysm" ]; then
 
-    CMD="/app/cmd/beacon-chain/beacon-chain --accept-terms-of-use --pyrmont --datadir /ethclient/prysm --p2p-tcp-port $ETH2_P2P_PORT --p2p-udp-port $ETH2_P2P_PORT --http-web3provider \"$ETH1_PROVIDER\" --rpc-host 0.0.0.0 --rpc-port 5052 --eth1-header-req-limit 150"
+    CMD="/app/cmd/beacon-chain/beacon-chain --accept-terms-of-use --pyrmont --datadir /ethclient/prysm --p2p-tcp-port $ETH2_P2P_PORT --p2p-udp-port $ETH2_P2P_PORT --http-web3provider $ETH1_PROVIDER --rpc-host 0.0.0.0 --rpc-port 5052 --eth1-header-req-limit 150"
 
     if [ ! -z "$ETH2_MAX_PEERS" ]; then
         CMD="$CMD --p2p-max-peers $ETH2_MAX_PEERS"
@@ -58,7 +59,7 @@ fi
 # Teku startup
 if [ "$CLIENT" = "teku" ]; then
 
-    CMD="/opt/teku/bin/teku --network=pyrmont --data-path=/ethclient/teku --p2p-port=$ETH2_P2P_PORT --eth1-endpoint=\"$ETH1_PROVIDER\" --rest-api-enabled --rest-api-interface=0.0.0.0 --rest-api-port=5052 --rest-api-host-allowlist='*' --eth1-deposit-contract-max-request-size=150"
+    CMD="/opt/teku/bin/teku --network=pyrmont --data-path=/ethclient/teku --p2p-port=$ETH2_P2P_PORT --eth1-endpoint=$ETH1_PROVIDER --rest-api-enabled --rest-api-interface=0.0.0.0 --rest-api-port=5052 --rest-api-host-allowlist='*' --eth1-deposit-contract-max-request-size=150"
 
     if [ ! -z "$ETH2_MAX_PEERS" ]; then
         CMD="$CMD --p2p-peer-upper-bound=$ETH2_MAX_PEERS"

--- a/rp-smartnode-install/network/pyrmont/chains/eth2/start-beacon.sh
+++ b/rp-smartnode-install/network/pyrmont/chains/eth2/start-beacon.sh
@@ -12,7 +12,13 @@ fi
 # Lighthouse startup
 if [ "$CLIENT" = "lighthouse" ]; then
 
-    exec /usr/local/bin/lighthouse beacon --network pyrmont --datadir /ethclient/lighthouse --port 9001 --discovery-port 9001 --eth1 --eth1-endpoints "$ETH1_PROVIDER" --http --http-address 0.0.0.0 --http-port 5052 --eth1-blocks-per-log-query 150 --disable-upnp
+    CMD="/usr/local/bin/lighthouse beacon --network pyrmont --datadir /ethclient/lighthouse --port $ETH2_P2P_PORT --discovery-port $ETH2_P2P_PORT --eth1 --eth1-endpoints \"$ETH1_PROVIDER\" --http --http-address 0.0.0.0 --http-port 5052 --eth1-blocks-per-log-query 150 --disable-upnp"
+
+    if [ ! -z "$ETH2_MAX_PEERS" ]; then
+        CMD="$CMD --target-peers $ETH2_MAX_PEERS"
+    fi
+
+    exec ${CMD}
 
 fi
 
@@ -24,9 +30,13 @@ if [ "$CLIENT" = "nimbus" ]; then
     mkdir -p /data/validators/nimbus/validators
     mkdir -p /data/validators/nimbus/secrets
 
-    # Run
-    exec /home/user/nimbus-eth2/build/nimbus_beacon_node --non-interactive --enr-auto-update --network=pyrmont --data-dir=/ethclient/nimbus --log-file="/ethclient/nimbus/nbc_bn_$(date +"%Y%m%d%H%M%S").log" --tcp-port=9001 --udp-port=9001 \
-    --web3-url="$ETH1_WS_PROVIDER" --rpc --rpc-address=0.0.0.0 --rpc-port=5052 --insecure-netkey-password=true --validators-dir=/data/validators/nimbus/validators --secrets-dir=/data/validators/nimbus/secrets --graffiti="$GRAFFITI"
+    CMD="/home/user/nimbus-eth2/build/nimbus_beacon_node --non-interactive --enr-auto-update --network=pyrmont --data-dir=/ethclient/nimbus --tcp-port=$ETH2_P2P_PORT --udp-port=$ETH2_P2P_PORT --web3-url=\"$ETH1_WS_PROVIDER\" --rpc --rpc-address=0.0.0.0 --rpc-port=5052 --insecure-netkey-password=true --validators-dir=/data/validators/nimbus/validators --secrets-dir=/data/validators/nimbus/secrets --graffiti=\"$GRAFFITI\""
+
+    if [ ! -z "$ETH2_MAX_PEERS" ]; then
+        CMD="$CMD --max-peers=$ETH2_MAX_PEERS"
+    fi
+
+    exec ${CMD}
 
 fi
 
@@ -34,7 +44,13 @@ fi
 # Prysm startup
 if [ "$CLIENT" = "prysm" ]; then
 
-    exec /app/cmd/beacon-chain/beacon-chain --accept-terms-of-use --pyrmont --datadir /ethclient/prysm --p2p-tcp-port 9001 --p2p-udp-port 9001 --http-web3provider "$ETH1_PROVIDER" --rpc-host 0.0.0.0 --rpc-port 5052 --eth1-header-req-limit 150
+    CMD="/app/cmd/beacon-chain/beacon-chain --accept-terms-of-use --pyrmont --datadir /ethclient/prysm --p2p-tcp-port $ETH2_P2P_PORT --p2p-udp-port $ETH2_P2P_PORT --http-web3provider \"$ETH1_PROVIDER\" --rpc-host 0.0.0.0 --rpc-port 5052 --eth1-header-req-limit 150"
+
+    if [ ! -z "$ETH2_MAX_PEERS" ]; then
+        CMD="$CMD --p2p-max-peers $ETH2_MAX_PEERS"
+    fi
+
+    exec ${CMD}
 
 fi
 
@@ -42,7 +58,12 @@ fi
 # Teku startup
 if [ "$CLIENT" = "teku" ]; then
 
-    exec /opt/teku/bin/teku --network=pyrmont --data-path=/ethclient/teku --p2p-port=9001 --eth1-endpoint="$ETH1_PROVIDER" --rest-api-enabled --rest-api-interface=0.0.0.0 --rest-api-port=5052 --rest-api-host-allowlist='*' --eth1-deposit-contract-max-request-size=150
+    CMD="/opt/teku/bin/teku --network=pyrmont --data-path=/ethclient/teku --p2p-port=$ETH2_P2P_PORT --eth1-endpoint=\"$ETH1_PROVIDER\" --rest-api-enabled --rest-api-interface=0.0.0.0 --rest-api-port=5052 --rest-api-host-allowlist='*' --eth1-deposit-contract-max-request-size=150"
+
+    if [ ! -z "$ETH2_MAX_PEERS" ]; then
+        CMD="$CMD --p2p-peer-upper-bound=$ETH2_MAX_PEERS"
+    fi
+
+    exec ${CMD}
 
 fi
-

--- a/rp-smartnode-install/network/pyrmont/config.yml
+++ b/rp-smartnode-install/network/pyrmont/config.yml
@@ -31,6 +31,21 @@ chains:
         - name: Ethstats Login
           desc: optional - for reporting Eth 1.0 node status to ethstats.net
           env: ETHSTATS_LOGIN
+        - name: Cache Size
+          desc: Geth's cache size, in MB - set this to 256 if you have 4 GB of RAM, or 512 if you have 8 GB
+          env: GETH_CACHE_SIZE
+          type: uint
+          blankText: the default of 1024
+        - name: Max Peers
+          desc: The maximum number of peers that Geth should connect to - this can be lowered down to 12 to improve performance on low-power systems or constrained networks
+          env: GETH_MAX_PEERS
+          type: uint
+          blankText: the default of 50
+        - name: P2P Port
+          desc: The port for Geth to use for P2P (blockchain) traffic
+          env: ETH1_P2P_PORT
+          blankText: the default of 30303
+          type: uint16
       - id: infura
         name: Infura
         desc: "\tUse infura.io as a light client for Eth 1.0. Not recommended\n
@@ -72,6 +87,15 @@ chains:
           desc: optional - for adding custom text to signed Eth 2.0 blocks - 16 chars max
           env: CUSTOM_GRAFFITI
           regex: ^.{0,16}$
+        - name: Target Peers
+          desc: The number of peer connections to maintain - you can try lowering this if you have a low-resource system or a constrained network (leave blank for the default of 50)
+          env: ETH2_MAX_PEERS
+          type: uint
+        - name: P2P Port
+          desc: The port to use for P2P (blockchain) traffic (leave blank for the default of 9001)
+          env: ETH2_P2P_PORT
+          type: uint16
+          default: 9001
       - id: nimbus
         name: Nimbus
         desc: "\tNimbus is a client implementation for both Ethereum 2.0 and\n
@@ -86,6 +110,15 @@ chains:
           desc: optional - for adding custom text to signed Eth 2.0 blocks - 16 chars max
           env: CUSTOM_GRAFFITI
           regex: ^.{0,16}$
+        - name: Max Peers
+          desc: The maximum number of peers to try to connect to - you can try lowering this if you have a low-resource system or a constrained network (leave blank for the default of 160)
+          env: ETH2_MAX_PEERS
+          type: uint
+        - name: P2P Port
+          desc: The port to use for P2P (blockchain) traffic (leave blank for the default of 9001)
+          env: ETH2_P2P_PORT
+          type: uint16
+          default: 9001
       - id: prysm
         name: Prysm
         desc: "\tPrysm is a Go implementation of Ethereum 2.0 protocol with a\n
@@ -101,6 +134,15 @@ chains:
           desc: optional - for adding custom text to signed Eth 2.0 blocks - 16 chars max
           env: CUSTOM_GRAFFITI
           regex: ^.{0,16}$
+        - name: Max Peers
+          desc: The maximum number of peers to try to connect to - you can try lowering this if you have a low-resource system or a constrained network (leave blank for the default of 45)
+          env: ETH2_MAX_PEERS
+          type: uint
+        - name: P2P Port
+          desc: The port to use for P2P (blockchain) traffic (leave blank for the default of 9001)
+          env: ETH2_P2P_PORT
+          type: uint16
+          default: 9001
       - id: teku
         name: Teku
         desc: "\tPegaSys Teku (formerly known as Artemis) is a Java-based\n 
@@ -117,3 +159,12 @@ chains:
           desc: optional - for adding custom text to signed Eth 2.0 blocks - 16 chars max
           env: CUSTOM_GRAFFITI
           regex: ^.{0,16}$
+        - name: Max Peers
+          desc: The maximum number of peers to try to connect to - you can try lowering this if you have a low-resource system or a constrained network (leave blank for the default of 74)
+          env: ETH2_MAX_PEERS
+          type: uint
+        - name: P2P Port
+          desc: The port to use for P2P (blockchain) traffic (leave blank for the default of 9001)
+          env: ETH2_P2P_PORT
+          type: uint16
+          default: 9001

--- a/rp-smartnode-install/network/pyrmont/config.yml
+++ b/rp-smartnode-install/network/pyrmont/config.yml
@@ -33,12 +33,15 @@ chains:
           desc: optional - for reporting Eth 1.0 node status to ethstats.net
           env: ETHSTATS_LOGIN
         - name: Cache Size
-          desc: Geth's cache size, in MB - set this to 256 if you have 4 GB of RAM, or 512 if you have 8 GB
+          desc: "Geth's cache size, in MB - set this to 256 if you have 4 GB\n
+            of RAM, or 512 if you have 8 GB"
           env: GETH_CACHE_SIZE
           type: uint
           blankText: the default of 1024
         - name: Max Peers
-          desc: The maximum number of peers that Geth should connect to - this can be lowered down to 12 to improve performance on low-power systems or constrained networks
+          desc: "The maximum number of peers that Geth should connect to -\n
+            this can be lowered down to 12 to improve performance on low-power\n
+            systems or constrained networks"
           env: GETH_MAX_PEERS
           type: uint
           blankText: the default of 50
@@ -89,14 +92,18 @@ chains:
           env: CUSTOM_GRAFFITI
           regex: ^.{0,16}$
         - name: Target Peers
-          desc: The number of peer connections to maintain - you can try lowering this if you have a low-resource system or a constrained network (leave blank for the default of 50)
+          desc: "The number of peer connections to maintain - you can try\n
+            lowering this if you have a low-resource system or a constrained\n
+            network"
           env: ETH2_MAX_PEERS
           type: uint
+          blankText: the default of 50
         - name: P2P Port
-          desc: The port to use for P2P (blockchain) traffic (leave blank for the default of 9001)
+          desc: The port to use for P2P (blockchain) traffic
           env: ETH2_P2P_PORT
           type: uint16
           default: 9001
+          blankText: the default of 9001
       - id: nimbus
         name: Nimbus
         desc: "\tNimbus is a client implementation for both Ethereum 2.0 and\n
@@ -112,14 +119,18 @@ chains:
           env: CUSTOM_GRAFFITI
           regex: ^.{0,16}$
         - name: Max Peers
-          desc: The maximum number of peers to try to connect to - you can try lowering this if you have a low-resource system or a constrained network (leave blank for the default of 160)
+          desc: "The maximum number of peers to try to connect to - you\n
+            can try lowering this if you have a low-resource system or\n
+            a constrained network"
           env: ETH2_MAX_PEERS
           type: uint
+          blankText: the default of 160
         - name: P2P Port
-          desc: The port to use for P2P (blockchain) traffic (leave blank for the default of 9001)
+          desc: The port to use for P2P (blockchain) traffic
           env: ETH2_P2P_PORT
           type: uint16
           default: 9001
+          blankText: the default of 9001
       - id: prysm
         name: Prysm
         desc: "\tPrysm is a Go implementation of Ethereum 2.0 protocol with a\n
@@ -136,14 +147,18 @@ chains:
           env: CUSTOM_GRAFFITI
           regex: ^.{0,16}$
         - name: Max Peers
-          desc: The maximum number of peers to try to connect to - you can try lowering this if you have a low-resource system or a constrained network (leave blank for the default of 45)
+          desc: "The maximum number of peers to try to connect to - you\n
+            can try lowering this if you have a low-resource system or\n
+            a constrained network"
           env: ETH2_MAX_PEERS
           type: uint
+          blankText: the default of 45
         - name: P2P Port
-          desc: The port to use for P2P (blockchain) traffic (leave blank for the default of 9001)
+          desc: The port to use for P2P (blockchain) traffic
           env: ETH2_P2P_PORT
           type: uint16
           default: 9001
+          blankText: the default of 9001
       - id: teku
         name: Teku
         desc: "\tPegaSys Teku (formerly known as Artemis) is a Java-based\n 
@@ -161,11 +176,15 @@ chains:
           env: CUSTOM_GRAFFITI
           regex: ^.{0,16}$
         - name: Max Peers
-          desc: The maximum number of peers to try to connect to - you can try lowering this if you have a low-resource system or a constrained network (leave blank for the default of 74)
+          desc: "The maximum number of peers to try to connect to - you\n
+            can try lowering this if you have a low-resource system or\n
+            a constrained network"
           env: ETH2_MAX_PEERS
           type: uint
+          blankText: the default of 74
         - name: P2P Port
-          desc: The port to use for P2P (blockchain) traffic (leave blank for the default of 9001)
+          desc: The port to use for P2P (blockchain) traffic
           env: ETH2_P2P_PORT
           type: uint16
           default: 9001
+          blankText: the default of 9001

--- a/rp-smartnode-install/network/pyrmont/docker-compose.yml
+++ b/rp-smartnode-install/network/pyrmont/docker-compose.yml
@@ -19,6 +19,9 @@ services:
       - ETHSTATS_LOGIN=${ETHSTATS_LOGIN}
       - INFURA_PROJECT_ID=${INFURA_PROJECT_ID}
       - PROVIDER_URL=${PROVIDER_URL}
+      - GETH_CACHE_SIZE=${GETH_CACHE_SIZE}
+      - GETH_MAX_PEERS=${GETH_MAX_PEERS}
+      - ETH1_P2P_PORT=${ETH1_P2P_PORT}
     entrypoint: sh
     command: "/setup/start-node.sh"
   eth2:
@@ -42,6 +45,8 @@ services:
       - ETH1_WS_PROVIDER=${ETH1_WS_PROVIDER}
       - CUSTOM_GRAFFITI=${CUSTOM_GRAFFITI}
       - ROCKET_POOL_VERSION=${ROCKET_POOL_VERSION}
+      - ETH2_P2P_PORT=${ETH2_P2P_PORT}
+      - ETH2_MAX_PEERS=${ETH2_MAX_PEERS}
     entrypoint: sh
     command: "/setup/start-beacon.sh"
     depends_on:


### PR DESCRIPTION
This is one of two PRs that adds some additional parameters to the `service config` interview process, the other being https://github.com/rocket-pool/smartnode/pull/128. This specific one adds some new settings to `config.yml` and handles them appropriately in `docker-compose.yml` and the start scripts. It also adds a parameter type field to `config.yml`, a default value field, and a "blank text" field. Here are the new settings:

For Geth:

- `GETH_CACHE_SIZE`, which controls the `--cache` flag for systems with low RAM
- `GETH_MAX_PEERS`, which controls the max number of peers to connect to
- `ETH1_P2P_PORT`, which controls the p2p port

For the ETH2 clients:

- `ETH2_MAX_PEERS`, which controls the max number of peers to connect to
- `ETH2_P2P_PORT`, which controls the p2p port

This fixes #40.

