### PR TITLE
Update start-beacon.sh

### DIFF
--- a/rp-smartnode-install/network/pyrmont/chains/eth2/start-beacon.sh
+++ b/rp-smartnode-install/network/pyrmont/chains/eth2/start-beacon.sh
@@ -59,7 +59,7 @@ fi
 # Teku startup
 if [ "$CLIENT" = "teku" ]; then
 
-    CMD="/opt/teku/bin/teku --network=pyrmont --data-path=/ethclient/teku --p2p-port=$ETH2_P2P_PORT --eth1-endpoint=$ETH1_PROVIDER --rest-api-enabled --rest-api-interface=0.0.0.0 --rest-api-port=5052 --rest-api-host-allowlist='*' --eth1-deposit-contract-max-request-size=150"
+    CMD="/opt/teku/bin/teku --network=pyrmont --data-path=/ethclient/teku --p2p-port=$ETH2_P2P_PORT --eth1-endpoint=$ETH1_PROVIDER --rest-api-enabled --rest-api-interface=0.0.0.0 --rest-api-port=5052 --rest-api-host-allowlist=* --eth1-deposit-contract-max-request-size=150"
 
     if [ ! -z "$ETH2_MAX_PEERS" ]; then
         CMD="$CMD --p2p-peer-upper-bound=$ETH2_MAX_PEERS"


### PR DESCRIPTION
Teku validator will fail to launch due to an 403

I think the asterisk gets expanded through exec.

Removing the quotes fixes this problem