### PR TITLE
Open Eth 1 docker container port 8545

### DIFF
--- a/amd64/rp-smartnode-install/network/pyrmont/docker-compose.yml
+++ b/amd64/rp-smartnode-install/network/pyrmont/docker-compose.yml
@@ -8,6 +8,7 @@ services:
     ports:
       - "30303:30303/udp"
       - "30303:30303/tcp"
+      - "8545:8545/tcp"
     volumes:
       - eth1clientdata:/ethclient
       - ./chains/eth1:/setup:ro

--- a/arm64/rp-smartnode-install/network/pyrmont/docker-compose.yml
+++ b/arm64/rp-smartnode-install/network/pyrmont/docker-compose.yml
@@ -8,6 +8,7 @@ services:
     ports:
       - "30303:30303/udp"
       - "30303:30303/tcp"
+      - "8545:8545/tcp"
     volumes:
       - eth1clientdata:/ethclient
       - ./chains/eth1:/setup:ro


### PR DESCRIPTION
Hello team - I am proposing this change to open up access to port 8545 from the eth1 docker container so users who are using external monitoring/validation tools on their Rocket Pool system can use them out of the box, without having to make any changes to docker-compose.yml themselves.

I tested the change on an Ubuntu 20.04 system and it works to open up for connections.

I understand if leaving it closed was a deliberate decision, so please merge at your discretion, or let me know if you have any feedback on the change.  Thanks!