### PR TITLE
Add eth2 client identifier to Graffiti to enable on-chain client diversity tracking

### DIFF
--- a/amd64/rp-smartnode-install/network/prater/chains/eth2/start-beacon.sh
+++ b/amd64/rp-smartnode-install/network/prater/chains/eth2/start-beacon.sh
@@ -2,8 +2,13 @@
 # This script launches ETH2 beacon clients for Rocket Pool's docker stack; only edit if you know what you're doing ;)
 
 
+# only show client identifier if version string is under 9 characters
+if ((${#ROCKET_POOL_VERSION} < 9)); then
+    IDENTIFIER="-${CLIENT::1}"
+fi
+
 # Get graffiti text
-GRAFFITI="RP $ROCKET_POOL_VERSION"
+GRAFFITI="RP${IDENTIFIER^^} $ROCKET_POOL_VERSION"
 if [ ! -z "$CUSTOM_GRAFFITI" ]; then
     GRAFFITI="$GRAFFITI ($CUSTOM_GRAFFITI)"
 fi

--- a/amd64/rp-smartnode-install/network/prater/chains/eth2/start-beacon.sh
+++ b/amd64/rp-smartnode-install/network/prater/chains/eth2/start-beacon.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # This script launches ETH2 beacon clients for Rocket Pool's docker stack; only edit if you know what you're doing ;)
 
 

--- a/amd64/rp-smartnode-install/network/prater/chains/eth2/start-beacon.sh
+++ b/amd64/rp-smartnode-install/network/prater/chains/eth2/start-beacon.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # This script launches ETH2 beacon clients for Rocket Pool's docker stack; only edit if you know what you're doing ;)
 
 

--- a/amd64/rp-smartnode-install/network/prater/chains/eth2/start-beacon.sh
+++ b/amd64/rp-smartnode-install/network/prater/chains/eth2/start-beacon.sh
@@ -3,12 +3,13 @@
 
 
 # only show client identifier if version string is under 9 characters
-if ((${#ROCKET_POOL_VERSION} < 9)); then
-    IDENTIFIER="-${CLIENT::1}"
+version_length=`echo -n $ROCKET_POOL_VERSION | wc -c`
+if [ $version_length -lt 9 ]; then
+    IDENTIFIER=`echo -n $CLIENT | head -c 1 | tr [a-z] [A-Z] | sed 's/^/-/'`
 fi
 
 # Get graffiti text
-GRAFFITI="RP${IDENTIFIER^^} $ROCKET_POOL_VERSION"
+GRAFFITI="RP$IDENTIFIER $ROCKET_POOL_VERSION"
 if [ ! -z "$CUSTOM_GRAFFITI" ]; then
     GRAFFITI="$GRAFFITI ($CUSTOM_GRAFFITI)"
 fi

--- a/amd64/rp-smartnode-install/network/prater/chains/eth2/start-validator.sh
+++ b/amd64/rp-smartnode-install/network/prater/chains/eth2/start-validator.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # This script launches ETH2 validator clients for Rocket Pool's docker stack; only edit if you know what you're doing ;)
 
 

--- a/amd64/rp-smartnode-install/network/prater/chains/eth2/start-validator.sh
+++ b/amd64/rp-smartnode-install/network/prater/chains/eth2/start-validator.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # This script launches ETH2 validator clients for Rocket Pool's docker stack; only edit if you know what you're doing ;)
 
 

--- a/amd64/rp-smartnode-install/network/prater/chains/eth2/start-validator.sh
+++ b/amd64/rp-smartnode-install/network/prater/chains/eth2/start-validator.sh
@@ -2,8 +2,13 @@
 # This script launches ETH2 validator clients for Rocket Pool's docker stack; only edit if you know what you're doing ;)
 
 
+# only show client identifier if version string is under 9 characters
+if ((${#ROCKET_POOL_VERSION} < 9)); then
+    IDENTIFIER="-${CLIENT::1}"
+fi
+
 # Get graffiti text
-GRAFFITI="RP $ROCKET_POOL_VERSION"
+GRAFFITI="RP${IDENTIFIER^^} $ROCKET_POOL_VERSION"
 if [ ! -z "$CUSTOM_GRAFFITI" ]; then
     GRAFFITI="$GRAFFITI ($CUSTOM_GRAFFITI)"
 fi

--- a/amd64/rp-smartnode-install/network/prater/chains/eth2/start-validator.sh
+++ b/amd64/rp-smartnode-install/network/prater/chains/eth2/start-validator.sh
@@ -3,12 +3,13 @@
 
 
 # only show client identifier if version string is under 9 characters
-if ((${#ROCKET_POOL_VERSION} < 9)); then
-    IDENTIFIER="-${CLIENT::1}"
+version_length=`echo -n $ROCKET_POOL_VERSION | wc -c`
+if [ $version_length -lt 9 ]; then
+    IDENTIFIER=`echo -n $CLIENT | head -c 1 | tr [a-z] [A-Z] | sed 's/^/-/'`
 fi
 
 # Get graffiti text
-GRAFFITI="RP${IDENTIFIER^^} $ROCKET_POOL_VERSION"
+GRAFFITI="RP$IDENTIFIER $ROCKET_POOL_VERSION"
 if [ ! -z "$CUSTOM_GRAFFITI" ]; then
     GRAFFITI="$GRAFFITI ($CUSTOM_GRAFFITI)"
 fi

--- a/amd64/rp-smartnode-install/network/pyrmont/chains/eth2/start-beacon.sh
+++ b/amd64/rp-smartnode-install/network/pyrmont/chains/eth2/start-beacon.sh
@@ -2,8 +2,13 @@
 # This script launches ETH2 beacon clients for Rocket Pool's docker stack; only edit if you know what you're doing ;)
 
 
+# only show client identifier if version string is under 9 characters
+if ((${#ROCKET_POOL_VERSION} < 9)); then
+    IDENTIFIER="-${CLIENT::1}"
+fi
+
 # Get graffiti text
-GRAFFITI="RP $ROCKET_POOL_VERSION"
+GRAFFITI="RP${IDENTIFIER^^} $ROCKET_POOL_VERSION"
 if [ ! -z "$CUSTOM_GRAFFITI" ]; then
     GRAFFITI="$GRAFFITI ($CUSTOM_GRAFFITI)"
 fi

--- a/amd64/rp-smartnode-install/network/pyrmont/chains/eth2/start-beacon.sh
+++ b/amd64/rp-smartnode-install/network/pyrmont/chains/eth2/start-beacon.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # This script launches ETH2 beacon clients for Rocket Pool's docker stack; only edit if you know what you're doing ;)
 
 

--- a/amd64/rp-smartnode-install/network/pyrmont/chains/eth2/start-beacon.sh
+++ b/amd64/rp-smartnode-install/network/pyrmont/chains/eth2/start-beacon.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # This script launches ETH2 beacon clients for Rocket Pool's docker stack; only edit if you know what you're doing ;)
 
 

--- a/amd64/rp-smartnode-install/network/pyrmont/chains/eth2/start-beacon.sh
+++ b/amd64/rp-smartnode-install/network/pyrmont/chains/eth2/start-beacon.sh
@@ -3,12 +3,13 @@
 
 
 # only show client identifier if version string is under 9 characters
-if ((${#ROCKET_POOL_VERSION} < 9)); then
-    IDENTIFIER="-${CLIENT::1}"
+version_length=`echo -n $ROCKET_POOL_VERSION | wc -c`
+if [ $version_length -lt 9 ]; then
+    IDENTIFIER=`echo -n $CLIENT | head -c 1 | tr [a-z] [A-Z] | sed 's/^/-/'`
 fi
 
 # Get graffiti text
-GRAFFITI="RP${IDENTIFIER^^} $ROCKET_POOL_VERSION"
+GRAFFITI="RP$IDENTIFIER $ROCKET_POOL_VERSION"
 if [ ! -z "$CUSTOM_GRAFFITI" ]; then
     GRAFFITI="$GRAFFITI ($CUSTOM_GRAFFITI)"
 fi

--- a/amd64/rp-smartnode-install/network/pyrmont/chains/eth2/start-validator.sh
+++ b/amd64/rp-smartnode-install/network/pyrmont/chains/eth2/start-validator.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # This script launches ETH2 validator clients for Rocket Pool's docker stack; only edit if you know what you're doing ;)
 
 

--- a/amd64/rp-smartnode-install/network/pyrmont/chains/eth2/start-validator.sh
+++ b/amd64/rp-smartnode-install/network/pyrmont/chains/eth2/start-validator.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # This script launches ETH2 validator clients for Rocket Pool's docker stack; only edit if you know what you're doing ;)
 
 

--- a/amd64/rp-smartnode-install/network/pyrmont/chains/eth2/start-validator.sh
+++ b/amd64/rp-smartnode-install/network/pyrmont/chains/eth2/start-validator.sh
@@ -2,8 +2,13 @@
 # This script launches ETH2 validator clients for Rocket Pool's docker stack; only edit if you know what you're doing ;)
 
 
+# only show client identifier if version string is under 9 characters
+if ((${#ROCKET_POOL_VERSION} < 9)); then
+    IDENTIFIER="-${CLIENT::1}"
+fi
+
 # Get graffiti text
-GRAFFITI="RP $ROCKET_POOL_VERSION"
+GRAFFITI="RP${IDENTIFIER^^} $ROCKET_POOL_VERSION"
 if [ ! -z "$CUSTOM_GRAFFITI" ]; then
     GRAFFITI="$GRAFFITI ($CUSTOM_GRAFFITI)"
 fi

--- a/amd64/rp-smartnode-install/network/pyrmont/chains/eth2/start-validator.sh
+++ b/amd64/rp-smartnode-install/network/pyrmont/chains/eth2/start-validator.sh
@@ -3,12 +3,13 @@
 
 
 # only show client identifier if version string is under 9 characters
-if ((${#ROCKET_POOL_VERSION} < 9)); then
-    IDENTIFIER="-${CLIENT::1}"
+version_length=`echo -n $ROCKET_POOL_VERSION | wc -c`
+if [ $version_length -lt 9 ]; then
+    IDENTIFIER=`echo -n $CLIENT | head -c 1 | tr [a-z] [A-Z] | sed 's/^/-/'`
 fi
 
 # Get graffiti text
-GRAFFITI="RP${IDENTIFIER^^} $ROCKET_POOL_VERSION"
+GRAFFITI="RP$IDENTIFIER $ROCKET_POOL_VERSION"
 if [ ! -z "$CUSTOM_GRAFFITI" ]; then
     GRAFFITI="$GRAFFITI ($CUSTOM_GRAFFITI)"
 fi

--- a/arm64/rp-smartnode-install/network/prater/chains/eth2/start-beacon.sh
+++ b/arm64/rp-smartnode-install/network/prater/chains/eth2/start-beacon.sh
@@ -2,8 +2,13 @@
 # This script launches ETH2 beacon clients for Rocket Pool's docker stack; only edit if you know what you're doing ;)
 
 
+# only show client identifier if version string is under 9 characters
+if ((${#ROCKET_POOL_VERSION} < 9)); then
+    IDENTIFIER="-${CLIENT::1}"
+fi
+
 # Get graffiti text
-GRAFFITI="RP $ROCKET_POOL_VERSION"
+GRAFFITI="RP${IDENTIFIER^^} $ROCKET_POOL_VERSION"
 if [ ! -z "$CUSTOM_GRAFFITI" ]; then
     GRAFFITI="$GRAFFITI ($CUSTOM_GRAFFITI)"
 fi

--- a/arm64/rp-smartnode-install/network/prater/chains/eth2/start-beacon.sh
+++ b/arm64/rp-smartnode-install/network/prater/chains/eth2/start-beacon.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # This script launches ETH2 beacon clients for Rocket Pool's docker stack; only edit if you know what you're doing ;)
 
 

--- a/arm64/rp-smartnode-install/network/prater/chains/eth2/start-beacon.sh
+++ b/arm64/rp-smartnode-install/network/prater/chains/eth2/start-beacon.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # This script launches ETH2 beacon clients for Rocket Pool's docker stack; only edit if you know what you're doing ;)
 
 

--- a/arm64/rp-smartnode-install/network/prater/chains/eth2/start-beacon.sh
+++ b/arm64/rp-smartnode-install/network/prater/chains/eth2/start-beacon.sh
@@ -3,12 +3,13 @@
 
 
 # only show client identifier if version string is under 9 characters
-if ((${#ROCKET_POOL_VERSION} < 9)); then
-    IDENTIFIER="-${CLIENT::1}"
+version_length=`echo -n $ROCKET_POOL_VERSION | wc -c`
+if [ $version_length -lt 9 ]; then
+    IDENTIFIER=`echo -n $CLIENT | head -c 1 | tr [a-z] [A-Z] | sed 's/^/-/'`
 fi
 
 # Get graffiti text
-GRAFFITI="RP${IDENTIFIER^^} $ROCKET_POOL_VERSION"
+GRAFFITI="RP$IDENTIFIER $ROCKET_POOL_VERSION"
 if [ ! -z "$CUSTOM_GRAFFITI" ]; then
     GRAFFITI="$GRAFFITI ($CUSTOM_GRAFFITI)"
 fi

--- a/arm64/rp-smartnode-install/network/prater/chains/eth2/start-validator.sh
+++ b/arm64/rp-smartnode-install/network/prater/chains/eth2/start-validator.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # This script launches ETH2 validator clients for Rocket Pool's docker stack; only edit if you know what you're doing ;)
 
 

--- a/arm64/rp-smartnode-install/network/prater/chains/eth2/start-validator.sh
+++ b/arm64/rp-smartnode-install/network/prater/chains/eth2/start-validator.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # This script launches ETH2 validator clients for Rocket Pool's docker stack; only edit if you know what you're doing ;)
 
 

--- a/arm64/rp-smartnode-install/network/prater/chains/eth2/start-validator.sh
+++ b/arm64/rp-smartnode-install/network/prater/chains/eth2/start-validator.sh
@@ -2,8 +2,13 @@
 # This script launches ETH2 validator clients for Rocket Pool's docker stack; only edit if you know what you're doing ;)
 
 
+# only show client identifier if version string is under 9 characters
+if ((${#ROCKET_POOL_VERSION} < 9)); then
+    IDENTIFIER="-${CLIENT::1}"
+fi
+
 # Get graffiti text
-GRAFFITI="RP $ROCKET_POOL_VERSION"
+GRAFFITI="RP${IDENTIFIER^^} $ROCKET_POOL_VERSION"
 if [ ! -z "$CUSTOM_GRAFFITI" ]; then
     GRAFFITI="$GRAFFITI ($CUSTOM_GRAFFITI)"
 fi

--- a/arm64/rp-smartnode-install/network/prater/chains/eth2/start-validator.sh
+++ b/arm64/rp-smartnode-install/network/prater/chains/eth2/start-validator.sh
@@ -3,12 +3,13 @@
 
 
 # only show client identifier if version string is under 9 characters
-if ((${#ROCKET_POOL_VERSION} < 9)); then
-    IDENTIFIER="-${CLIENT::1}"
+version_length=`echo -n $ROCKET_POOL_VERSION | wc -c`
+if [ $version_length -lt 9 ]; then
+    IDENTIFIER=`echo -n $CLIENT | head -c 1 | tr [a-z] [A-Z] | sed 's/^/-/'`
 fi
 
 # Get graffiti text
-GRAFFITI="RP${IDENTIFIER^^} $ROCKET_POOL_VERSION"
+GRAFFITI="RP$IDENTIFIER $ROCKET_POOL_VERSION"
 if [ ! -z "$CUSTOM_GRAFFITI" ]; then
     GRAFFITI="$GRAFFITI ($CUSTOM_GRAFFITI)"
 fi

--- a/arm64/rp-smartnode-install/network/pyrmont/chains/eth2/start-beacon.sh
+++ b/arm64/rp-smartnode-install/network/pyrmont/chains/eth2/start-beacon.sh
@@ -2,8 +2,13 @@
 # This script launches ETH2 beacon clients for Rocket Pool's docker stack; only edit if you know what you're doing ;)
 
 
+# only show client identifier if version string is under 9 characters
+if ((${#ROCKET_POOL_VERSION} < 9)); then
+    IDENTIFIER="-${CLIENT::1}"
+fi
+
 # Get graffiti text
-GRAFFITI="RP $ROCKET_POOL_VERSION"
+GRAFFITI="RP${IDENTIFIER^^} $ROCKET_POOL_VERSION"
 if [ ! -z "$CUSTOM_GRAFFITI" ]; then
     GRAFFITI="$GRAFFITI ($CUSTOM_GRAFFITI)"
 fi

--- a/arm64/rp-smartnode-install/network/pyrmont/chains/eth2/start-beacon.sh
+++ b/arm64/rp-smartnode-install/network/pyrmont/chains/eth2/start-beacon.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # This script launches ETH2 beacon clients for Rocket Pool's docker stack; only edit if you know what you're doing ;)
 
 

--- a/arm64/rp-smartnode-install/network/pyrmont/chains/eth2/start-beacon.sh
+++ b/arm64/rp-smartnode-install/network/pyrmont/chains/eth2/start-beacon.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # This script launches ETH2 beacon clients for Rocket Pool's docker stack; only edit if you know what you're doing ;)
 
 

--- a/arm64/rp-smartnode-install/network/pyrmont/chains/eth2/start-beacon.sh
+++ b/arm64/rp-smartnode-install/network/pyrmont/chains/eth2/start-beacon.sh
@@ -3,12 +3,13 @@
 
 
 # only show client identifier if version string is under 9 characters
-if ((${#ROCKET_POOL_VERSION} < 9)); then
-    IDENTIFIER="-${CLIENT::1}"
+version_length=`echo -n $ROCKET_POOL_VERSION | wc -c`
+if [ $version_length -lt 9 ]; then
+    IDENTIFIER=`echo -n $CLIENT | head -c 1 | tr [a-z] [A-Z] | sed 's/^/-/'`
 fi
 
 # Get graffiti text
-GRAFFITI="RP${IDENTIFIER^^} $ROCKET_POOL_VERSION"
+GRAFFITI="RP$IDENTIFIER $ROCKET_POOL_VERSION"
 if [ ! -z "$CUSTOM_GRAFFITI" ]; then
     GRAFFITI="$GRAFFITI ($CUSTOM_GRAFFITI)"
 fi

--- a/arm64/rp-smartnode-install/network/pyrmont/chains/eth2/start-validator.sh
+++ b/arm64/rp-smartnode-install/network/pyrmont/chains/eth2/start-validator.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # This script launches ETH2 validator clients for Rocket Pool's docker stack; only edit if you know what you're doing ;)
 
 

--- a/arm64/rp-smartnode-install/network/pyrmont/chains/eth2/start-validator.sh
+++ b/arm64/rp-smartnode-install/network/pyrmont/chains/eth2/start-validator.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # This script launches ETH2 validator clients for Rocket Pool's docker stack; only edit if you know what you're doing ;)
 
 

--- a/arm64/rp-smartnode-install/network/pyrmont/chains/eth2/start-validator.sh
+++ b/arm64/rp-smartnode-install/network/pyrmont/chains/eth2/start-validator.sh
@@ -2,8 +2,13 @@
 # This script launches ETH2 validator clients for Rocket Pool's docker stack; only edit if you know what you're doing ;)
 
 
+# only show client identifier if version string is under 9 characters
+if ((${#ROCKET_POOL_VERSION} < 9)); then
+    IDENTIFIER="-${CLIENT::1}"
+fi
+
 # Get graffiti text
-GRAFFITI="RP $ROCKET_POOL_VERSION"
+GRAFFITI="RP${IDENTIFIER^^} $ROCKET_POOL_VERSION"
 if [ ! -z "$CUSTOM_GRAFFITI" ]; then
     GRAFFITI="$GRAFFITI ($CUSTOM_GRAFFITI)"
 fi

--- a/arm64/rp-smartnode-install/network/pyrmont/chains/eth2/start-validator.sh
+++ b/arm64/rp-smartnode-install/network/pyrmont/chains/eth2/start-validator.sh
@@ -3,12 +3,13 @@
 
 
 # only show client identifier if version string is under 9 characters
-if ((${#ROCKET_POOL_VERSION} < 9)); then
-    IDENTIFIER="-${CLIENT::1}"
+version_length=`echo -n $ROCKET_POOL_VERSION | wc -c`
+if [ $version_length -lt 9 ]; then
+    IDENTIFIER=`echo -n $CLIENT | head -c 1 | tr [a-z] [A-Z] | sed 's/^/-/'`
 fi
 
 # Get graffiti text
-GRAFFITI="RP${IDENTIFIER^^} $ROCKET_POOL_VERSION"
+GRAFFITI="RP$IDENTIFIER $ROCKET_POOL_VERSION"
 if [ ! -z "$CUSTOM_GRAFFITI" ]; then
     GRAFFITI="$GRAFFITI ($CUSTOM_GRAFFITI)"
 fi


### PR DESCRIPTION
Allows for on-chain client diversity information. Other approaches (such as an API endpoint) would be less spam-resilient and could theoretically expose Stakers more (their IP address could be leaked if the endpoint gets compromised).

Uses a single character to be space efficient and completely disappears if there isn't enough space for it.


```
Calculations are:
+  2 characters: Prefix "RP"
+  3-1 characters: Client Identifier "-N " or " "
+  6-10 characters: Version string "v1.0.0" ... "v1.0.0-b.0"
+  3 characters: Decorator when using a custom graffiti " ()"
+ 16 characters: Custom graffiti, which has a 16 character limit according to the config regex.
------
  30-32 characters in total
```

Some Examples:
- Without Custom Graffiti:
`RP-T v1.1.1` (11)
- Different Clients:
Teku: `RP-T v1.1.1 (0123456789ABCDEF)` (30)
Lighthouse: `RP-L v1.1.1 (0123456789ABCDEF)` (30)
Prysm: `RP-P v1.1.1 (0123456789ABCDEF)` (30)
Nimbus: `RP-N v1.1.1 (0123456789ABCDEF)` (30)
- Different Versions:
`RP-N v1.1.1 (0123456789ABCDEF)` (30)
`RP-N v1.11.1 (0123456789ABCDEF)` (31)
`RP-N v1.11.11 (0123456789ABCDEF)` (32)
`RP v1.11.1-b (0123456789ABCDEF)` (31)
`RP v1.1.1-b.1 (0123456789ABCDEF)` (32)
`RP v1.1.1-rc1 (0123456789ABCDEF)` (32)