### PR TITLE
Automatic prometheus datasource and dashboard provisioning for Grafana

### DIFF
--- a/amd64/rp-smartnode-install/network/prater/docker-compose-metrics.yml
+++ b/amd64/rp-smartnode-install/network/prater/docker-compose-metrics.yml
@@ -41,6 +41,8 @@ services:
     ports: 
       - "${GRAFANA_PORT:-3100}:${GRAFANA_PORT:-3100}/tcp"
     volumes:
+      - "./grafana/prometheus-datasource.yml:/etc/grafana/provisioning/datasources/prometheus.yml"
+      - "./grafana/dashboards/provisioning.yml:/etc/grafana/provisioning/dashboards/dashboards.yml"
       - "grafana-storage:/var/lib/grafana"
     networks:
       - net

--- a/amd64/rp-smartnode-install/network/prater/grafana/dashboards/provisioning.yml
+++ b/amd64/rp-smartnode-install/network/prater/grafana/dashboards/provisioning.yml
@@ -1,0 +1,14 @@
+apiVersion: 1
+
+providers:
+  - name: "Dashboard provisioning"
+    orgId: 1
+    folder: ""
+    folderUid: ""
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 10
+    allowUiUpdates: true
+    options:
+      path: /etc/grafana/provisioning/dashboards
+      foldersFromFilesStructure: true

--- a/amd64/rp-smartnode-install/network/prater/grafana/prometheus-datasource.yml
+++ b/amd64/rp-smartnode-install/network/prater/grafana/prometheus-datasource.yml
@@ -1,0 +1,16 @@
+apiVersion: 1
+
+deleteDatasources:
+  - name: Prometheus
+    orgId: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    orgId: 1
+    url: http://prometheus:9091
+    basicAuth: false
+    isDefault: true
+    version: 1
+    editable: true


### PR DESCRIPTION
This PR is not complete or tested but it should be what's needed to automatically provision Grafana with a prometheus datasource and give the user a way to drop dashboard json-files in `grafana/dashboards/` to provision with dashboards of their choice. This could also be part of the `rocketpool config`-step to select a dashboard and get provisioned automatically.

If you like the idea I could finish it.