### PR TITLE
Use timer for RP update check instead of apt hook

### DIFF
--- a/install-update-tracker.sh
+++ b/install-update-tracker.sh
@@ -123,7 +123,7 @@ case "$INSTALLER" in
     apt)
 
         # The total number of steps in the installation process
-        TOTAL_STEPS="3"
+        TOTAL_STEPS="4"
         
         # Install dependencies 
         progress 1 "Installing dependencies..."
@@ -143,8 +143,18 @@ case "$INSTALLER" in
         { sudo mv "$PACKAGE_FILES_PATH/apt/apt-metrics.sh" "$UPDATE_SCRIPT_PATH" || fail "Could not move apt update collector."; } >&2
         { sudo mv "$PACKAGE_FILES_PATH/rp-version-check.sh" "$UPDATE_SCRIPT_PATH" || fail "Could not move Rocket Pool update collector."; } >&2
         { sudo mv "$PACKAGE_FILES_PATH/apt/apt-prometheus-metrics" "/etc/apt/apt.conf.d/60prometheus-metrics" || fail "Could not move apt trigger."; } >&2
+        { sudo mv "$PACKAGE_FILES_PATH/apt/rp-check.sh" "$UPDATE_SCRIPT_PATH" || fail "Could not move Rocket Pool update tracker script."; } >&2
+        { sudo mv "$PACKAGE_FILES_PATH/apt/rp-update-tracker.service" "/etc/systemd/system" || fail "Could not move update tracker service."; } >&2
+        { sudo mv "$PACKAGE_FILES_PATH/apt/rp-update-tracker.timer" "/etc/systemd/system" || fail "Could not move update tracker timer."; } >&2
         { sudo chmod +x "$UPDATE_SCRIPT_PATH/apt-metrics.sh" || fail "Could not set permissions on apt update collector."; } >&2
         { sudo chmod +x "$UPDATE_SCRIPT_PATH/rp-version-check.sh" || fail "Could not set permissions on Rocket Pool update collector."; } >&2
+        { sudo chmod +x "$UPDATE_SCRIPT_PATH/rp-check.sh" || fail "Could not set permissions on Rocket Pool update tracker script."; } >&2
+
+        # Install the update checking service
+        progress 4 "Installing Rocket Pool update tracker service..."
+        { sudo systemctl daemon-reload || fail "Couldn't update systemctl daemons."; } >&2
+        { sudo systemctl enable rp-update-tracker || fail "Couldn't enable update tracker service."; } >&2
+        { sudo systemctl start rp-update-tracker || fail "Couldn't start update tracker service."; } >&2
 
     ;;
 

--- a/rp-update-tracker/apt/apt-prometheus-metrics
+++ b/rp-update-tracker/apt/apt-prometheus-metrics
@@ -1,9 +1,7 @@
 APT::Update::Post-Invoke-Success {
   "/usr/share/apt-metrics.sh | sponge /var/lib/node_exporter/textfile_collector/apt.prom || true";
-  "/usr/share/rp-version-check.sh | sponge /var/lib/node_exporter/textfile_collector/rp.prom || true";
 };
 
 DPkg::Post-Invoke {
   "/usr/share/apt-metrics.sh | sponge /var/lib/node_exporter/textfile_collector/apt.prom || true";
-  "/usr/share/rp-version-check.sh | sponge /var/lib/node_exporter/textfile_collector/rp.prom || true";
 };

--- a/rp-update-tracker/apt/rp-check.sh
+++ b/rp-update-tracker/apt/rp-check.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+/usr/share/rp-version-check.sh | sponge /var/lib/node_exporter/textfile_collector/rp.prom || true

--- a/rp-update-tracker/apt/rp-update-tracker.service
+++ b/rp-update-tracker/apt/rp-update-tracker.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Checks for Rocket Pool updates periodically
+Wants=rp-update-tracker.timer
+
+[Service]
+Type=oneshot
+ExecStart=/usr/share/rp-check.sh
+
+[Install]
+WantedBy=multi-user.target

--- a/rp-update-tracker/apt/rp-update-tracker.timer
+++ b/rp-update-tracker/apt/rp-update-tracker.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Timer for the Rocket Pool updates tracker
+Requires=rp-update-tracker.service
+
+[Timer]
+Unit=rp-update-tracker.service
+OnCalendar=*-*-* *:00:00
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
Use the same systemd timer that is used for `dnf`/`yum` based updates only for RP update checks. APT hook is still in place for apt updates.

I tested this in a fresh Ubuntu 20.04 VM with a mainnet `rocketpool service install` and both the apt hook and timer work to populate apt.prom and rp.prom.