### PR TITLE
Check to ensure rocketpool_node is running

### DIFF
--- a/rp-update-tracker/rp-version-check.sh
+++ b/rp-update-tracker/rp-version-check.sh
@@ -1,12 +1,17 @@
 #!/bin/sh
-
-LATEST_VERSION=$(curl --silent "https://api.github.com/repos/rocket-pool/smartnode-install/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
-CURRENT_VERSION=$(docker exec rocketpool_node /go/bin/rocketpool --version | sed -E 's/rocketpool version (.*)/v\1/')
-
 echo "# HELP rocketpool_version_update New Rocket Pool version available"
 echo "# TYPE rocketpool_version_update gauge"
-if [ "$LATEST_VERSION" = "$CURRENT_VERSION" ]; then
-    echo "rocketpool_version_update 0"
+
+if [ "$(docker ps -aq -f status=running -f name=rocketpool_node)" ]; then
+    LATEST_VERSION=$(curl --silent "https://api.github.com/repos/rocket-pool/smartnode-install/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
+    CURRENT_VERSION=$(docker exec rocketpool_node /go/bin/rocketpool --version | sed -E 's/rocketpool version (.*)/v\1/')
+
+    if [ "$LATEST_VERSION" = "$CURRENT_VERSION" ]; then
+        echo "rocketpool_version_update 0"
+    else
+        echo "rocketpool_version_update 1"
+    fi
+    
 else
-    echo "rocketpool_version_update 1"
+    echo "rocketpool_version_update 0"
 fi


### PR DESCRIPTION
Reduces false positives for the RP update check by ensuring that the `rocketpool_node` container is running prior to checking its version.