### PR TITLE
Fall back to rsync when cp fails in install script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -300,7 +300,7 @@ progress 7 "Downloading Rocket Pool package files..."
 # Copy package files
 progress 8 "Copying package files to Rocket Pool user data directory..."
 { cp -r "$PACKAGE_FILES_PATH/addons" "$RP_PATH" || fail "Could not copy addons folder to the Rocket Pool user data directory."; } >&2
-{ cp -r -n "$PACKAGE_FILES_PATH/override" "$RP_PATH" || fail "Could not copy new override files to the Rocket Pool user data directory."; } >&2
+{ cp -r -n "$PACKAGE_FILES_PATH/override" "$RP_PATH" || rsync -r --ignore-existing "$PACKAGE_FILES_PATH/override" "$RP_PATH" || fail "Could not copy new override files to the Rocket Pool user data directory."; } >&2
 { cp -r "$PACKAGE_FILES_PATH/scripts" "$RP_PATH" || fail "Could not copy scripts folder to the Rocket Pool user data directory."; } >&2
 { cp -r "$PACKAGE_FILES_PATH/templates" "$RP_PATH" || fail "Could not copy templates folder to the Rocket Pool user data directory."; } >&2
 { cp "$PACKAGE_FILES_PATH/grafana-prometheus-datasource.yml" "$PACKAGE_FILES_PATH/prometheus.tmpl" "$RP_PATH" || fail "Could not copy base files to the Rocket Pool user data directory."; } >&2


### PR DESCRIPTION
Alpine Linux does not support the `-n, --no-clobber ` option for `cp`.

```bash
rocket-pool:/tmp$ cp -r -n hi.txt bye.txt
cp: unrecognized option: n
```

With this change, the installer falls back to `rsync`, when the `cp` command fails due to `-n` being unsupported. Note that Alpine users may need to install rsync to benefit from this change.