### PR TITLE
Added EC_CLIENT environment var to node.tmpl

### DIFF
--- a/install/templates/node.tmpl
+++ b/install/templates/node.tmpl
@@ -17,6 +17,8 @@ services:
       - ${ROCKETPOOL_DATA_FOLDER}:/.rocketpool/data
     networks:
       - net
+    environment:
+      - EC_CLIENT=${EC_CLIENT}
     command: "-m 0.0.0.0 -r ${NODE_METRICS_PORT:-9102} node"
     cap_drop:
       - all


### PR DESCRIPTION
This should fix the issue people are having with Grafana no longer showing stats after changing their EC, because the node container wasn't restarted after the change.
I'm sure there are more elegant ways to do this, but it works.