### PR TITLE
Fix sh syntax error in start-ec.sh

### DIFF
--- a/install/scripts/start-ec.sh
+++ b/install/scripts/start-ec.sh
@@ -198,7 +198,7 @@ if [ "$CLIENT" = "nethermind" ]; then
 
     if [ "$ENABLE_METRICS" = "true" ]; then
         CMD="$CMD --Metrics.Enabled true --Metrics.ExposePort $EC_METRICS_PORT"
-        if [ "$NETWORK" == "prater" ]; then
+        if [ "$NETWORK" = "prater" ]; then
             CMD="$CMD --Metrics.PushGatewayUrl=\"\""
         fi
     fi


### PR DESCRIPTION
Seeing this upon startup for nethermind ec
![image](https://user-images.githubusercontent.com/856738/230267235-a283b528-4cb0-4ab5-a41a-1d5d06e33def.png)

I think this is due to a sh syntax error https://stackoverflow.com/a/18102991