### PR TITLE
Properly handle case of unknown external IP

### DIFF
--- a/install/scripts/start-bn.sh
+++ b/install/scripts/start-bn.sh
@@ -183,7 +183,7 @@ if [ "$CC_CLIENT" = "nimbus" ]; then
         CMD="$CMD --metrics --metrics-address=0.0.0.0 --metrics-port=$BN_METRICS_PORT"
     fi
 
-    if [ ! -z "$EXTERNAL_IP" ]; then
+    if [ ! -z "$EXTERNAL_IP" ] && [ "$EXTERNAL_IP" != "''" ]; then
         CMD="$CMD --nat=extip:$EXTERNAL_IP"
     fi
 


### PR DESCRIPTION
The `smartnode` applies `shellescape.Quote` to environment variables. When no external IP address is known (e.g., in an intermittent outage), `EXTERNAL_IP` is set to `shellescape.Quote("")` which is `''`. However, in `smartnode-install` we check for an actually empty string. Our check incorrectly assumes that `''` is a valid IP address, and then proceeds to try and start Nimbus using `--nat=extip:''`, which fails. This is fixed by also checking that `EXTERNAL_IP` is not set to `''`.