### PR TITLE
Provide checkpoint sync URL to Lodestar even if db folder exists

### DIFF
--- a/install/scripts/start-bn.sh
+++ b/install/scripts/start-bn.sh
@@ -140,13 +140,7 @@ if [ "$CC_CLIENT" = "lodestar" ]; then
     fi
 
     if [ ! -z "$CHECKPOINT_SYNC_URL" ]; then
-        # Ignore it if a DB already exists
-        if [ -d "/ethclient/lodestar/chain-db" ]; then
-            echo "Lodestar database already exists, ignoring checkpoint sync."
-        else
-            echo "No database detected, enabling checkpoint sync."
-            CMD="$CMD --checkpointSyncUrl $CHECKPOINT_SYNC_URL"
-        fi
+        CMD="$CMD --checkpointSyncUrl $CHECKPOINT_SYNC_URL"
     fi
 
     exec ${CMD}


### PR DESCRIPTION
While reviewing the Lodestar configuration I noticed that `--checkpointSyncUrl` is not set if db folder exists.

This is not ideal as it introduces a risk that the db state is outside of the weak subjectivity period (~15 days on mainnet) if node has been offline for a while leaving it susceptible to [long range attacks](https://ethereum.org/en/developers/docs/consensus-mechanisms/pos/attack-and-defense/#long-range-attacks).

Should let Lodestar decide if it needs to fetch the checkpoint sync URL or not, this is how it works:
- empty db => fetch from URL
- last db state is within ws period => init from db state
- last state is outside of ws period => fetch from URL