### PR TITLE
Update Lodestar CLI flag to enable doppelganger protection

### DIFF
--- a/install/scripts/start-vc.sh
+++ b/install/scripts/start-vc.sh
@@ -97,7 +97,7 @@ if [ "$CC_CLIENT" = "lodestar" ]; then
         $VC_ADDITIONAL_FLAGS"
 
     if [ "$DOPPELGANGER_DETECTION" = "true" ]; then
-        CMD="$CMD --doppelgangerProtectionEnabled"
+        CMD="$CMD --doppelgangerProtection"
     fi
 
     if [ ! -z "$MEV_BOOST_URL" ]; then


### PR DESCRIPTION
Updates Lodestar CLI flag to enable doppelganger protection to `--doppelgangerProtection`. Previous value still works as an alias but this one it now referenced in our docs.

![image](https://github.com/rocket-pool/smartnode-install/assets/38436224/91a9f735-8393-4c22-9598-5c0fd2090df6)


Requires Lodestar [v1.10.0](https://github.com/ChainSafe/lodestar/releases/tag/v1.10.0)