### PR TITLE
fix: set Lodestar VC builder flag if MEV boost is enabled

### DIFF
--- a/install/scripts/start-vc.sh
+++ b/install/scripts/start-vc.sh
@@ -100,7 +100,7 @@ if [ "$CC_CLIENT" = "lodestar" ]; then
         CMD="$CMD --doppelgangerProtection"
     fi
 
-    if [ ! -z "$MEV_BOOST_URL" ]; then
+    if [ "$ENABLE_MEV_BOOST" = "true" ]; then
         CMD="$CMD --builder"
     fi
 


### PR DESCRIPTION
Correctly check if MEV boost is enabled on Lodestar VC startup and set --builder flag.

`MEV_BOOST_URL` does not seem to be set on validator client
```bash
$ docker exec -it rocketpool_validator printenv | grep MEV_BOOST_URL
MEV_BOOST_URL=
$ docker exec -it rocketpool_validator printenv | grep ENABLE_MEV_BOOST
ENABLE_MEV_BOOST=true
```

This also aligns the check with how it is done for other VCs.