### PR TITLE
Allow custom prometheus targets via file_sd_config

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -407,7 +407,7 @@ progress 6 "Creating Rocket Pool user data directory..."
 { mkdir -p "$RP_PATH/runtime" || fail "Could not create the Rocket Pool runtime directory."; } >&2
 { mkdir -p "$DATA_PATH/secrets" || fail "Could not create the Rocket Pool secrets directory."; } >&2
 { mkdir -p "$DATA_PATH/rewards-trees" || fail "Could not create the Rocket Pool rewards trees directory."; } >&2
-{ mkdir -p "$RP_PATH/extra_scrape_jobs" || fail "Could not create the Prometheus extra scrape jobs directory."; } >&2
+{ mkdir -p "$RP_PATH/extra-scrape-jobs" || fail "Could not create the Prometheus extra scrape jobs directory."; } >&2
 
 
 # Download and extract package files

--- a/install.sh
+++ b/install.sh
@@ -407,6 +407,7 @@ progress 6 "Creating Rocket Pool user data directory..."
 { mkdir -p "$RP_PATH/runtime" || fail "Could not create the Rocket Pool runtime directory."; } >&2
 { mkdir -p "$DATA_PATH/secrets" || fail "Could not create the Rocket Pool secrets directory."; } >&2
 { mkdir -p "$DATA_PATH/rewards-trees" || fail "Could not create the Rocket Pool rewards trees directory."; } >&2
+{ mkdir -p "$RP_PATH/extra_scrape_jobs" || fail "Could not create the Prometheus extra scrape jobs directory."; } >&2
 
 
 # Download and extract package files

--- a/install/prometheus.tmpl
+++ b/install/prometheus.tmpl
@@ -44,3 +44,8 @@ scrape_configs:
     scrape_timeout: 5m
     static_configs:
       - targets: ['watchtower:${WATCHTOWER_METRICS_PORT:-9104}']
+
+  - job_name: 'dummy' # Mandatory field, but will be ignored.
+    file_sd_configs:
+      - files:
+        - /extra_scrape_jobs/*.yml

--- a/install/prometheus.tmpl
+++ b/install/prometheus.tmpl
@@ -45,7 +45,7 @@ scrape_configs:
     static_configs:
       - targets: ['watchtower:${WATCHTOWER_METRICS_PORT:-9104}']
 
-  - job_name: 'dummy' # Mandatory field, but will be ignored.
+  - job_name: 'custom_jobs' # Mandatory field, but will be ignored.
     file_sd_configs:
       - files:
-        - /extra_scrape_jobs/*.yml
+        - /extra-scrape-jobs/*.yml

--- a/install/templates/prometheus.tmpl
+++ b/install/templates/prometheus.tmpl
@@ -15,6 +15,7 @@ services:
     ports: [${PROMETHEUS_OPEN_PORTS}]
     volumes:
       - "${ROCKETPOOL_FOLDER}/prometheus.yml:/etc/prometheus/prometheus.yml"
+      - "${ROCKETPOOL_FOLDER}/extra_scrape_jobs:/extra_scrape_jobs"
       - "prometheus-data:/prometheus"
     networks:
       - net

--- a/install/templates/prometheus.tmpl
+++ b/install/templates/prometheus.tmpl
@@ -15,7 +15,7 @@ services:
     ports: [${PROMETHEUS_OPEN_PORTS}]
     volumes:
       - "${ROCKETPOOL_FOLDER}/prometheus.yml:/etc/prometheus/prometheus.yml"
-      - "${ROCKETPOOL_FOLDER}/extra_scrape_jobs:/extra_scrape_jobs"
+      - "${ROCKETPOOL_FOLDER}/extra-scrape-jobs:/extra-scrape-jobs"
       - "prometheus-data:/prometheus"
     networks:
       - net


### PR DESCRIPTION
This creates a folder on install, `~/.rocketpool/extra_scrape_jobs`, which is mounted into the prometheus container.

Prometheus is configured to check for any `.yml` file extension in that volume and treat it as a config file, allowing users who run other applications in rocketpool_net (ie, eth docker in reverse hybrid mode) to create scrape configs that survive smartnode upgrades.