### PR TITLE
Replace Prometheus envsubst variables with text/template variables

### DIFF
--- a/install/prometheus.tmpl
+++ b/install/prometheus.tmpl
@@ -8,42 +8,42 @@ global:
 scrape_configs:
   - job_name: 'prometheus'
     static_configs:
-      - targets: ['localhost:${PROMETHEUS_PORT:-9091}']
+      - targets: ['localhost:{{or (index . "PROMETHEUS_PORT") "9091"}}']
 
   - job_name: 'node'
     static_configs:
       # node-exporter is on the host network so it can get access to the actual machine's network info
       # We have to use 'hosts.docker.internal' to refer to it due to this configuration
-      - targets: ['host.docker.internal:${EXPORTER_METRICS_PORT:-9103}']
+      - targets: ['host.docker.internal:{{or (index . "EXPORTER_METRICS_PORT") "9103"}}']
 
   - job_name: 'geth'
     static_configs:
-      - targets: ['${EC_HOSTNAME:-eth1}:${EC_METRICS_PORT:-9105}']
+      - targets: ['{{or (index . "EC_HOSTNAME") "eth1"}}:{{or (index . "EC_METRICS_PORT") "9105"}}']
     metrics_path: /debug/metrics/prometheus
 
   - job_name: 'eth1'
     static_configs:
-      - targets: ['${EC_HOSTNAME:-eth1}:${EC_METRICS_PORT:-9105}']
+      - targets: ['{{or (index . "EC_HOSTNAME") "eth1"}}:{{or (index . "EC_METRICS_PORT") "9105"}}']
 
   - job_name: 'eth2'
     static_configs:
-      - targets: ['${CC_HOSTNAME:-eth2}:${BN_METRICS_PORT:-9100}']
+      - targets: ['{{or (index . "CC_HOSTNAME") "eth2"}}:{{or (index . "BN_METRICS_PORT") "9100"}}']
 
   - job_name: 'validator'
     static_configs:
-      - targets: ['validator:${VC_METRICS_PORT:-9101}']
+      - targets: ['validator:{{or (index . "VC_METRICS_PORT") "9101"}}']
 
   - job_name: 'rocketpool'
     scrape_interval: 5m
     scrape_timeout: 5m
     static_configs:
-      - targets: ['node:${NODE_METRICS_PORT:-9102}']
+      - targets: ['node:{{or (index . "NODE_METRICS_PORT") "9102"}}']
 
   - job_name: 'watchtower'
     scrape_interval: 5m
     scrape_timeout: 5m
     static_configs:
-      - targets: ['watchtower:${WATCHTOWER_METRICS_PORT:-9104}']
+      - targets: ['watchtower:{{or (index . "WATCHTOWER_METRICS_PORT") "9104"}}']
 
   - job_name: 'custom_jobs' # Mandatory field, but will be ignored.
     file_sd_configs:

--- a/install/prometheus.tmpl
+++ b/install/prometheus.tmpl
@@ -16,14 +16,12 @@ scrape_configs:
       # We have to use 'hosts.docker.internal' to refer to it due to this configuration
       - targets: ['host.docker.internal:{{or .ExporterMetricsPort.Value "9103"}}']
 
-  - job_name: 'geth'
+  - job_name: '{{if (eq .ExecutionClient.Value "geth")}}geth{{else}}eth1{{end}}'
     static_configs:
       - targets: ['{{.GetExecutionHostname}}:{{or .EcMetricsPort.Value "9105"}}']
+    {{- if (eq .ExecutionClient.Value "geth")}}
     metrics_path: /debug/metrics/prometheus
-
-  - job_name: 'eth1'
-    static_configs:
-      - targets: ['{{.GetExecutionHostname}}:{{or .EcMetricsPort.Value "9105"}}']
+    {{- end}}
 
   - job_name: 'eth2'
     static_configs:

--- a/install/prometheus.tmpl
+++ b/install/prometheus.tmpl
@@ -8,42 +8,42 @@ global:
 scrape_configs:
   - job_name: 'prometheus'
     static_configs:
-      - targets: ['localhost:{{or (index . "PROMETHEUS_PORT") "9091"}}']
+      - targets: ['localhost:{{or .Prometheus.Port.Value "9091"}}']
 
   - job_name: 'node'
     static_configs:
       # node-exporter is on the host network so it can get access to the actual machine's network info
       # We have to use 'hosts.docker.internal' to refer to it due to this configuration
-      - targets: ['host.docker.internal:{{or (index . "EXPORTER_METRICS_PORT") "9103"}}']
+      - targets: ['host.docker.internal:{{or .ExporterMetricsPort.Value "9103"}}']
 
   - job_name: 'geth'
     static_configs:
-      - targets: ['{{or (index . "EC_HOSTNAME") "eth1"}}:{{or (index . "EC_METRICS_PORT") "9105"}}']
+      - targets: ['{{.GetExecutionHostname}}:{{or .EcMetricsPort.Value "9105"}}']
     metrics_path: /debug/metrics/prometheus
 
   - job_name: 'eth1'
     static_configs:
-      - targets: ['{{or (index . "EC_HOSTNAME") "eth1"}}:{{or (index . "EC_METRICS_PORT") "9105"}}']
+      - targets: ['{{.GetExecutionHostname}}:{{or .EcMetricsPort.Value "9105"}}']
 
   - job_name: 'eth2'
     static_configs:
-      - targets: ['{{or (index . "CC_HOSTNAME") "eth2"}}:{{or (index . "BN_METRICS_PORT") "9100"}}']
+      - targets: ['{{.GetConsensusHostname}}:{{or .BnMetricsPort.Value "9100"}}']
 
   - job_name: 'validator'
     static_configs:
-      - targets: ['validator:{{or (index . "VC_METRICS_PORT") "9101"}}']
+      - targets: ['validator:{{or .VcMetricsPort.Value "9101"}}']
 
   - job_name: 'rocketpool'
     scrape_interval: 5m
     scrape_timeout: 5m
     static_configs:
-      - targets: ['node:{{or (index . "NODE_METRICS_PORT") "9102"}}']
+      - targets: ['node:{{or .NodeMetricsPort.Value "9102"}}']
 
   - job_name: 'watchtower'
     scrape_interval: 5m
     scrape_timeout: 5m
     static_configs:
-      - targets: ['watchtower:{{or (index . "WATCHTOWER_METRICS_PORT") "9104"}}']
+      - targets: ['watchtower:{{or .WatchtowerMetricsPort.Value "9104"}}']
 
   - job_name: 'custom_jobs' # Mandatory field, but will be ignored.
     file_sd_configs:

--- a/install/prometheus.tmpl
+++ b/install/prometheus.tmpl
@@ -16,10 +16,10 @@ scrape_configs:
       # We have to use 'hosts.docker.internal' to refer to it due to this configuration
       - targets: ['host.docker.internal:{{or .ExporterMetricsPort.Value "9103"}}']
 
-  - job_name: '{{if (eq .ExecutionClient.Value "geth")}}geth{{else}}eth1{{end}}'
+  - job_name: '{{if (eq .ExecutionClient.String "geth")}}geth{{else}}eth1{{end}}'
     static_configs:
       - targets: ['{{.GetExecutionHostname}}:{{or .EcMetricsPort.Value "9105"}}']
-    {{- if (eq .ExecutionClient.Value "geth")}}
+    {{- if (eq .ExecutionClient.String "geth")}}
     metrics_path: /debug/metrics/prometheus
     {{- end}}
 

--- a/install/templates/addons/gww/addon_gww.tmpl
+++ b/install/templates/addons/gww/addon_gww.tmpl
@@ -8,25 +8,25 @@
 version: "3.7"
 services:
   addon_gww:
-    image: ${ADDON_GWW_CONTAINER_TAG}
+    image: {{.GraffitiWallWriter.GetConfig.ContainerTag.Value}}
     user: root
-    container_name: ${COMPOSE_PROJECT_NAME}_addon_gww
+    container_name: {{.Smartnode.ProjectName.Value}}_addon_gww
     restart: unless-stopped
     volumes:
-      - ${ROCKETPOOL_FOLDER}/addons/gww:/gww
+      - {{.RocketPoolDirectory}}/addons/gww:/gww
     networks:
       - net
     entrypoint:
       - /go/bin/drawer
       - --output_file=/gww/graffiti.txt
-      - --input_url=${ADDON_GWW_INPUT_URL}
-      - --consensus_client=${CC_CLIENT}
-      - --nimbus_url=http://${CC_HOSTNAME:-eth2}:${BN_API_PORT:-5052}
-      - --graffiti_prefix=${GRAFFITI_PREFIX}
-      - --network=${NETWORK}
-      - --update_wall_time=${ADDON_GWW_UPDATE_WALL_TIME}
-      - --update_input_time=${ADDON_GWW_UPDATE_INPUT_TIME}
-      - --update_pixel_time=${ADDON_GWW_UPDATE_PIXEL_TIME}
+      - --input_url={{.GraffitiWallWriter.GetConfig.InputURL.Value}}
+      - --consensus_client={{if .ConsensusClientLocal}}{{.ConsensusClient.Value}}{{else}}{{.ExternalConsensusClient.Value}}{{end}}
+      - --nimbus_url=http://{{.GetConsensusHostname}}:{{or .ConsensusCommon.ApiPort.Value}}
+      - --graffiti_prefix={{.GraffitiPrefix}}
+      - --network={{.Smartnode.Network.Value}}
+      - --update_wall_time={{.GraffitiWallWriter.GetConfig.UpdateWallTime.Value}}
+      - --update_input_time={{.GraffitiWallWriter.GetConfig.UpdateInputTime.Value}}
+      - --update_pixel_time={{.GraffitiWallWriter.GetConfig.UpdatePixelTime.Value}}
     cap_drop:
       - all
     security_opt:

--- a/install/templates/addons/gww/addon_gww.tmpl
+++ b/install/templates/addons/gww/addon_gww.tmpl
@@ -8,9 +8,9 @@
 version: "3.7"
 services:
   addon_gww:
-    image: {{.GraffitiWallWriter.GetConfig.ContainerTag.Value}}
+    image: {{.GraffitiWallWriter.GetConfig.ContainerTag}}
     user: root
-    container_name: {{.Smartnode.ProjectName.Value}}_addon_gww
+    container_name: {{.Smartnode.ProjectName}}_addon_gww
     restart: unless-stopped
     volumes:
       - {{.RocketPoolDirectory}}/addons/gww:/gww
@@ -19,14 +19,14 @@ services:
     entrypoint:
       - /go/bin/drawer
       - --output_file=/gww/graffiti.txt
-      - --input_url={{.GraffitiWallWriter.GetConfig.InputURL.Value}}
-      - --consensus_client={{if .ConsensusClientLocal}}{{.ConsensusClient.Value}}{{else}}{{.ExternalConsensusClient.Value}}{{end}}
-      - --nimbus_url=http://{{.GetConsensusHostname}}:{{or .ConsensusCommon.ApiPort.Value}}
+      - --input_url={{.GraffitiWallWriter.GetConfig.InputURL}}
+      - --consensus_client={{if .ConsensusClientLocal}}{{.ConsensusClient}}{{else}}{{.ExternalConsensusClient}}{{end}}
+      - --nimbus_url=http://{{.GetConsensusHostname}}:{{or .ConsensusCommon.ApiPort}}
       - --graffiti_prefix={{.GraffitiPrefix}}
-      - --network={{.Smartnode.Network.Value}}
-      - --update_wall_time={{.GraffitiWallWriter.GetConfig.UpdateWallTime.Value}}
-      - --update_input_time={{.GraffitiWallWriter.GetConfig.UpdateInputTime.Value}}
-      - --update_pixel_time={{.GraffitiWallWriter.GetConfig.UpdatePixelTime.Value}}
+      - --network={{.Smartnode.Network}}
+      - --update_wall_time={{.GraffitiWallWriter.GetConfig.UpdateWallTime}}
+      - --update_input_time={{.GraffitiWallWriter.GetConfig.UpdateInputTime}}
+      - --update_pixel_time={{.GraffitiWallWriter.GetConfig.UpdatePixelTime}}
     cap_drop:
       - all
     security_opt:

--- a/install/templates/api.tmpl
+++ b/install/templates/api.tmpl
@@ -9,14 +9,14 @@ version: "3.7"
 services:
   api:
     image: {{.Smartnode.GetSmartnodeContainerTag}}
-    container_name: {{.Smartnode.ProjectName.Value}}_api
+    container_name: {{.Smartnode.ProjectName}}_api
     restart: unless-stopped
     stop_signal: SIGKILL
     stop_grace_period: 1s
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - {{.RocketPoolDirectory}}:/.rocketpool
-      - {{.Smartnode.DataPath.Value}}:/.rocketpool/data
+      - {{.Smartnode.DataPath}}:/.rocketpool/data
     networks:
       - net
     entrypoint: /bin/sleep

--- a/install/templates/api.tmpl
+++ b/install/templates/api.tmpl
@@ -8,15 +8,15 @@
 version: "3.7"
 services:
   api:
-    image: ${SMARTNODE_IMAGE}
-    container_name: ${COMPOSE_PROJECT_NAME}_api
+    image: {{.Smartnode.GetSmartnodeContainerTag}}
+    container_name: {{.Smartnode.ProjectName.Value}}_api
     restart: unless-stopped
     stop_signal: SIGKILL
     stop_grace_period: 1s
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
-      - ${ROCKETPOOL_FOLDER}:/.rocketpool
-      - ${ROCKETPOOL_DATA_FOLDER}:/.rocketpool/data
+      - {{.RocketPoolDirectory}}:/.rocketpool
+      - {{.Smartnode.DataPath.Value}}:/.rocketpool/data
     networks:
       - net
     entrypoint: /bin/sleep

--- a/install/templates/eth1.tmpl
+++ b/install/templates/eth1.tmpl
@@ -10,7 +10,7 @@ services:
   eth1:
     image: {{.GetECContainerTag}}
     user: root
-    container_name: {{.Smartnode.ProjectName.Value}}_eth1
+    container_name: {{.Smartnode.ProjectName}}_eth1
     restart: unless-stopped
     stop_signal: {{.GetECStopSignal}}
     stop_grace_period: 15m
@@ -23,31 +23,31 @@ services:
     networks:
       - net
     environment:
-      - NETWORK={{.Smartnode.Network.Value}}
-      - CLIENT={{.ExecutionClient.Value}}
-      - ETHSTATS_LABEL={{.ExecutionCommon.EthstatsLabel.Value}}
-      - ETHSTATS_LOGIN={{.ExecutionCommon.EthstatsLogin.Value}}
+      - NETWORK={{.Smartnode.Network}}
+      - CLIENT={{.ExecutionClient}}
+      - ETHSTATS_LABEL={{.ExecutionCommon.EthstatsLabel}}
+      - ETHSTATS_LOGIN={{.ExecutionCommon.EthstatsLogin}}
       - EC_MAX_PEERS={{.GetECMaxPeers}}
       - EC_P2P_PORT={{$p2p}}
       - EC_ADDITIONAL_FLAGS={{.GetECAdditionalFlags}}
-      - EC_HTTP_PORT={{.ExecutionCommon.HttpPort.Value}}
-      - EC_WS_PORT={{.ExecutionCommon.WsPort.Value}}
-      - EC_ENGINE_PORT={{.ExecutionCommon.EnginePort.Value}}
+      - EC_HTTP_PORT={{.ExecutionCommon.HttpPort}}
+      - EC_WS_PORT={{.ExecutionCommon.WsPort}}
+      - EC_ENGINE_PORT={{.ExecutionCommon.EnginePort}}
       - EXTERNAL_IP={{.GetExternalIp}}
-      - ENABLE_METRICS={{.EnableMetrics.Value}}
-      - EC_METRICS_PORT={{.EcMetricsPort.Value}}
+      - ENABLE_METRICS={{.EnableMetrics}}
+      - EC_METRICS_PORT={{.EcMetricsPort}}
       {{- /* Client-specific values */}}
-      {{- if eq .ExecutionClient.Value "besu"}}
-      - BESU_MAX_BACK_LAYERS={{.Besu.MaxBackLayers.Value}}
-      - BESU_JVM_HEAP_SIZE={{.Besu.JvmHeapSize.Value}}
-      {{- else if eq .ExecutionClient.Value "nethermind"}}
-      - EC_CACHE_SIZE={{.Nethermind.CacheSize.Value}}
-      - RP_NETHERMIND_PRUNE_MEM_SIZE={{.Nethermind.PruneMemSize.Value}}
-      - RP_NETHERMIND_ADDITIONAL_MODULES={{.Nethermind.AdditionalModules.Value}}
-      - RP_NETHERMIND_ADDITIONAL_URLS={{.Nethermind.AdditionalUrls.Value}}
-      - RP_NETHERMIND_COMPLETE_HISTORY={{.Nethermind.DownloadCompleteHistory.Value}}
-      {{- else if eq .ExecutionClient.Value "geth"}}
-      - RP_GETH_ENABLE_PBSS={{.Geth.EnablePbss.Value}}
+      {{- if eq .ExecutionClient.String "besu"}}
+      - BESU_MAX_BACK_LAYERS={{.Besu.MaxBackLayers}}
+      - BESU_JVM_HEAP_SIZE={{.Besu.JvmHeapSize}}
+      {{- else if eq .ExecutionClient.String "nethermind"}}
+      - EC_CACHE_SIZE={{.Nethermind.CacheSize}}
+      - RP_NETHERMIND_PRUNE_MEM_SIZE={{.Nethermind.PruneMemSize}}
+      - RP_NETHERMIND_ADDITIONAL_MODULES={{.Nethermind.AdditionalModules}}
+      - RP_NETHERMIND_ADDITIONAL_URLS={{.Nethermind.AdditionalUrls}}
+      - RP_NETHERMIND_COMPLETE_HISTORY={{.Nethermind.DownloadCompleteHistory}}
+      {{- else if eq .ExecutionClient.String "geth"}}
+      - RP_GETH_ENABLE_PBSS={{.Geth.EnablePbss}}
       {{- end}}
     entrypoint: sh
     command: "/setup/start-ec.sh"

--- a/install/templates/eth1.tmpl
+++ b/install/templates/eth1.tmpl
@@ -8,13 +8,14 @@
 version: "3.7"
 services:
   eth1:
-    image: ${EC_CONTAINER_TAG}
+    image: {{.GetECContainerTag}}
     user: root
-    container_name: ${COMPOSE_PROJECT_NAME}_eth1
+    container_name: {{.Smartnode.ProjectName.Value}}_eth1
     restart: unless-stopped
-    stop_signal: ${EC_STOP_SIGNAL}
+    stop_signal: {{.GetECStopSignal}}
     stop_grace_period: 15m
-    ports: [ "${EC_P2P_PORT:-30303}:${EC_P2P_PORT:-30303}/udp", "${EC_P2P_PORT:-30303}:${EC_P2P_PORT:-30303}/tcp"${EC_OPEN_API_PORTS} ]
+    {{- $p2p := (or .ExecutionCommon.P2pPort.Value "30303")}}
+    ports: [ "{{$p2p}}:{{$p2p}}/udp", "{{$p2p}}:{{$p2p}}/tcp"{{.GetECOpenAPIPorts}} ]
     volumes:
       - eth1clientdata:/ethclient
       - ${ROCKETPOOL_FOLDER}/scripts:/setup:ro
@@ -22,28 +23,32 @@ services:
     networks:
       - net
     environment:
-      - NETWORK=${NETWORK}
-      - CLIENT=${EC_CLIENT}
-      - ETHSTATS_LABEL=${ETHSTATS_LABEL}
-      - ETHSTATS_LOGIN=${ETHSTATS_LOGIN}
-      - EC_CACHE_SIZE=${EC_CACHE_SIZE}
-      - EC_MAX_PEERS=${EC_MAX_PEERS}
-      - EC_P2P_PORT=${EC_P2P_PORT}
-      - EC_ADDITIONAL_FLAGS=${EC_ADDITIONAL_FLAGS}
-      - EC_HTTP_PORT=${EC_HTTP_PORT}
-      - EC_WS_PORT=${EC_WS_PORT}
-      - EC_ENGINE_PORT=${EC_ENGINE_PORT}
-      - RP_NETHERMIND_PRUNE_MEM_SIZE=${NETHERMIND_PRUNE_MEM_SIZE}
-      - BESU_MAX_BACK_LAYERS=${BESU_MAX_BACK_LAYERS}
-      - BESU_JVM_HEAP_SIZE=${BESU_JVM_HEAP_SIZE}
-      - EXTERNAL_IP=${EXTERNAL_IP}
-      - ENABLE_METRICS=${ENABLE_METRICS}
-      - EC_METRICS_PORT=${EC_METRICS_PORT}
-      - TTD_OVERRIDE=${TTD_OVERRIDE}
-      - RP_NETHERMIND_ADDITIONAL_MODULES=${NETHERMIND_ADDITIONAL_MODULES}
-      - RP_NETHERMIND_ADDITIONAL_URLS=${NETHERMIND_ADDITIONAL_URLS}
-      - RP_NETHERMIND_COMPLETE_HISTORY=${NETHERMIND_COMPLETE_HISTORY}
-      - RP_GETH_ENABLE_PBSS=${GETH_ENABLE_PBSS}
+      - NETWORK={{.Smartnode.Network.Value}}
+      - CLIENT={{.ExecutionClient.Value}}
+      - ETHSTATS_LABEL={{.ExecutionCommon.EthstatsLabel.Value}}
+      - ETHSTATS_LOGIN={{.ExecutionCommon.EthstatsLogin.Value}}
+      - EC_MAX_PEERS={{.GetECMaxPeers}}
+      - EC_P2P_PORT={{$p2p}}
+      - EC_ADDITIONAL_FLAGS={{.GetECAdditionalFlags}}
+      - EC_HTTP_PORT={{.ExecutionCommon.HttpPort.Value}}
+      - EC_WS_PORT={{.ExecutionCommon.WsPort.Value}}
+      - EC_ENGINE_PORT={{.ExecutionCommon.EnginePort.Value}}
+      - EXTERNAL_IP={{.GetExternalIp}}
+      - ENABLE_METRICS={{.EnableMetrics.Value}}
+      - EC_METRICS_PORT={{.EcMetricsPort.Value}}
+      {{- /* Client-specific values */}}
+      {{- if eq .ExecutionClient.Value "besu"}}
+      - BESU_MAX_BACK_LAYERS={{.Besu.MaxBackLayers.Value}}
+      - BESU_JVM_HEAP_SIZE={{.Besu.JvmHeapSize.Value}}
+      {{- else if eq .ExecutionClient.Value "nethermind"}}
+      - EC_CACHE_SIZE={{.Nethermind.CacheSize.Value}}
+      - RP_NETHERMIND_PRUNE_MEM_SIZE={{.Nethermind.PruneMemSize.Value}}
+      - RP_NETHERMIND_ADDITIONAL_MODULES={{.Nethermind.AdditionalModules.Value}}
+      - RP_NETHERMIND_ADDITIONAL_URLS={{.Nethermind.AdditionalUrls.Value}}
+      - RP_NETHERMIND_COMPLETE_HISTORY={{.Nethermind.DownloadCompleteHistory.Value}}
+      {{- else if eq .ExecutionClient.Value "geth"}}
+      - RP_GETH_ENABLE_PBSS={{.Geth.EnablePbss.Value}}
+      {{- end}}
     entrypoint: sh
     command: "/setup/start-ec.sh"
     cap_drop:

--- a/install/templates/eth2.tmpl
+++ b/install/templates/eth2.tmpl
@@ -8,54 +8,57 @@
 version: "3.7"
 services:
   eth2:
-    image: ${BN_CONTAINER_TAG}
+    image: {{.GetBeaconContainerTag}}
     user: root
-    container_name: ${COMPOSE_PROJECT_NAME}_eth2
+    container_name: {{.Smartnode.ProjectName.Value}}_eth2
     restart: unless-stopped
     stop_grace_period: 3m
-    ports: [ "${BN_P2P_PORT:-9001}:${BN_P2P_PORT:-9001}/tcp", "${BN_P2P_PORT:-9001}:${BN_P2P_PORT:-9001}/udp"${BN_OPEN_PORTS}, "${BN_P2P_QUIC_PORT:-8001}:${BN_P2P_QUIC_PORT:-8001}/udp"]
+    {{- $p2p := (or .ConsensusCommon.P2pPort.Value "9001")}}
+    ports: [ "{{$p2p}}:{{$p2p}}/udp", "{{$p2p}}:{{$p2p}}/tcp"{{.GetBnOpenPorts}} ]
     volumes:
-      - ${ROCKETPOOL_DATA_FOLDER}/validators:/validators
-      - ${ROCKETPOOL_DATA_FOLDER}/secrets:/secrets:ro
+      - {{.Smartnode.DataPath.Value}}/validators:/validators
+      - {{.Smartnode.DataPath.Value}}/secrets:/secrets:ro
       - eth2clientdata:/ethclient
-      - ${ROCKETPOOL_FOLDER}/scripts:/setup:ro
+      - {{.RocketPoolDirectory}}/scripts:/setup:ro
     networks:
       - net
     environment:
-      - NETWORK=${NETWORK}
-      - EC_CLIENT=${EC_CLIENT}
-      - CC_CLIENT=${CC_CLIENT}
-      - EC_HTTP_ENDPOINT=${EC_HTTP_ENDPOINT}
-      - EC_WS_ENDPOINT=${EC_WS_ENDPOINT}
-      - EC_ENGINE_ENDPOINT=${EC_ENGINE_ENDPOINT}
-      - EC_ENGINE_WS_ENDPOINT=${EC_ENGINE_WS_ENDPOINT}
-      - CUSTOM_GRAFFITI=${CUSTOM_GRAFFITI}
-      - ROCKET_POOL_VERSION=${ROCKET_POOL_VERSION}
-      - BN_P2P_PORT=${BN_P2P_PORT}
-      - BN_API_PORT=${BN_API_PORT}
-      - BN_RPC_PORT=${BN_RPC_PORT}
-      - BN_P2P_QUIC_PORT=${BN_P2P_QUIC_PORT}
-      - BN_MAX_PEERS=${BN_MAX_PEERS}
-      - ENABLE_METRICS=${ENABLE_METRICS}
-      - BN_METRICS_PORT=${BN_METRICS_PORT}
-      - EXTERNAL_IP=${EXTERNAL_IP}
-      - CHECKPOINT_SYNC_URL=${CHECKPOINT_SYNC_URL}
-      - DOPPELGANGER_DETECTION=${DOPPELGANGER_DETECTION}
-      - BN_ADDITIONAL_FLAGS=${BN_ADDITIONAL_FLAGS}
-      - NODE_FEE_RECIPIENT=${NODE_FEE_RECIPIENT}
-      - FEE_RECIPIENT_FILE=${FEE_RECIPIENT_FILE}
-      - ENABLE_BITFLY_NODE_METRICS=${ENABLE_BITFLY_NODE_METRICS}
-      - BITFLY_NODE_METRICS_SECRET=${BITFLY_NODE_METRICS_SECRET}
-      - BITFLY_NODE_METRICS_ENDPOINT=${BITFLY_NODE_METRICS_ENDPOINT}
-      - BITFLY_NODE_METRICS_MACHINE_NAME=${BITFLY_NODE_METRICS_MACHINE_NAME}
-      - TEKU_JVM_HEAP_SIZE=${TEKU_JVM_HEAP_SIZE}
-      - MEV_BOOST_URL=${MEV_BOOST_URL}
-      - RETH_ADDRESS=${RETH_ADDRESS}
-      - GRAFFITI=${GRAFFITI}
-      - ADDON_GWW_ENABLED=${ADDON_GWW_ENABLED}
-      - TTD_OVERRIDE=${TTD_OVERRIDE}
-      - TEKU_ARCHIVE_MODE=${TEKU_ARCHIVE_MODE}
-      - NIMBUS_PRUNING_MODE=${NIMBUS_PRUNING_MODE}
+      - NETWORK={{.Smartnode.Network.Value}}
+      - EC_CLIENT={{if .ExecutionClientLocal}}{{.ExecutionClient.Value}}{{else}}X{{end}}
+      - CC_CLIENT={{if .ConsensusClientLocal}}{{.ConsensusClient.Value}}{{else}}{{.ExternalConsensusClient.Value}}{{end}}
+      - EC_HTTP_ENDPOINT={{.GetEcHttpEndpoint}}
+      - EC_WS_ENDPOINT={{.GetEcWsEndpoint}}
+      - EC_ENGINE_ENDPOINT=http://{{.GetExecutionHostname}}:{{.ExecutionCommon.EnginePort.Value}}
+      - EC_ENGINE_WS_ENDPOINT=ws://{{.GetExecutionHostname}}:{{.ExecutionCommon.EnginePort.Value}}
+      - CUSTOM_GRAFFITI={{.CustomGraffiti}}
+      - ROCKET_POOL_VERSION=v{{.RocketPoolVersion}}
+      - BN_P2P_PORT={{$p2p}}
+      - BN_API_PORT={{.ConsensusCommon.ApiPort.Value}}
+      - BN_MAX_PEERS={{.GetBNMaxPeers}}
+      - ENABLE_METRICS={{.EnableMetrics.Value}}
+      - BN_METRICS_PORT={{.BnMetricsPort.Value}}
+      - EXTERNAL_IP={{.GetExternalIp}}
+      - CHECKPOINT_SYNC_URL={{.ConsensusCommon.CheckpointSyncProvider.Value}}
+      - DOPPELGANGER_DETECTION={{.IsDoppelgangerEnabled}}
+      - BN_ADDITIONAL_FLAGS={{.GetBNAdditionalFlags}}
+      - FEE_RECIPIENT_FILE={{.FeeRecipientFile}}
+      - ENABLE_BITFLY_NODE_METRICS={{.EnableBitflyNodeMetrics.Value}}
+      - BITFLY_NODE_METRICS_SECRET={{.BitflyNodeMetrics.Secret.Value}}
+      - BITFLY_NODE_METRICS_ENDPOINT={{.BitflyNodeMetrics.Endpoint.Value}}
+      - BITFLY_NODE_METRICS_MACHINE_NAME={{.BitflyNodeMetrics.MachineName.Value}}
+      - MEV_BOOST_URL={{.MevBoostUrl}}
+      - RETH_ADDRESS={{.Smartnode.GetRethAddress.Hex}}
+      - GRAFFITI={{.Graffiti}}
+      - ADDON_GWW_ENABLED={{.GraffitiWallWriter.GetEnabledParameter.Value}}
+      {{- /* Client-specific values */}}
+      {{- if eq .ConsensusClient.Value "teku"}}
+      - TEKU_JVM_HEAP_SIZE={{.Teku.JvmHeapSize.Value}}
+      - TEKU_ARCHIVE_MODE={{.Teku.ArchiveMode.Value}}
+      {{- else if eq .ConsensusClient.Value "prysm"}}
+      - BN_RPC_PORT={{.Prysm.RpcPort.Value}}
+      {{- else if eq .ConsensusClient.Value "nimbus"}}
+      - NIMBUS_PRUNING_MODE={{.Nimbus.PruningMode.Value}}
+      {{- end}}
     entrypoint: sh
     command: "/setup/start-bn.sh"
     cap_drop:

--- a/install/templates/eth2.tmpl
+++ b/install/templates/eth2.tmpl
@@ -14,7 +14,15 @@ services:
     restart: unless-stopped
     stop_grace_period: 3m
     {{- $p2p := (or .ConsensusCommon.P2pPort.Value "9001")}}
-    ports: [ "{{$p2p}}:{{$p2p}}/udp", "{{$p2p}}:{{$p2p}}/tcp"{{.GetBnOpenPorts}} ]
+    ports:
+      - "{{$p2p}}:{{$p2p}}/udp"
+      - "{{$p2p}}:{{$p2p}}/tcp"
+      {{- if eq .ConsensusClient.Value "lighthouse"}}
+      - "{{.Lighthouse.P2pQuicPort.Value}}:{{.Lighthouse.P2pQuicPort.Value}}/udp"
+      {{- end}}
+      {{- range $entry := .GetBnOpenPorts}}
+      - "{{$entry}}"
+      {{- end}}
     volumes:
       - {{.Smartnode.DataPath.Value}}/validators:/validators
       - {{.Smartnode.DataPath.Value}}/secrets:/secrets:ro

--- a/install/templates/eth2.tmpl
+++ b/install/templates/eth2.tmpl
@@ -10,62 +10,62 @@ services:
   eth2:
     image: {{.GetBeaconContainerTag}}
     user: root
-    container_name: {{.Smartnode.ProjectName.Value}}_eth2
+    container_name: {{.Smartnode.ProjectName}}_eth2
     restart: unless-stopped
     stop_grace_period: 3m
-    {{- $p2p := (or .ConsensusCommon.P2pPort.Value "9001")}}
+    {{- $p2p := (or .ConsensusCommon.P2pPort.String "9001")}}
     ports:
       - "{{$p2p}}:{{$p2p}}/udp"
       - "{{$p2p}}:{{$p2p}}/tcp"
-      {{- if eq .ConsensusClient.Value "lighthouse"}}
-      - "{{.Lighthouse.P2pQuicPort.Value}}:{{.Lighthouse.P2pQuicPort.Value}}/udp"
+      {{- if eq .ConsensusClient.String "lighthouse"}}
+      - "{{.Lighthouse.P2pQuicPort}}:{{.Lighthouse.P2pQuicPort}}/udp"
       {{- end}}
       {{- range $entry := .GetBnOpenPorts}}
       - "{{$entry}}"
       {{- end}}
     volumes:
-      - {{.Smartnode.DataPath.Value}}/validators:/validators
-      - {{.Smartnode.DataPath.Value}}/secrets:/secrets:ro
+      - {{.Smartnode.DataPath}}/validators:/validators
+      - {{.Smartnode.DataPath}}/secrets:/secrets:ro
       - eth2clientdata:/ethclient
       - {{.RocketPoolDirectory}}/scripts:/setup:ro
     networks:
       - net
     environment:
-      - NETWORK={{.Smartnode.Network.Value}}
-      - EC_CLIENT={{if .ExecutionClientLocal}}{{.ExecutionClient.Value}}{{else}}X{{end}}
-      - CC_CLIENT={{if .ConsensusClientLocal}}{{.ConsensusClient.Value}}{{else}}{{.ExternalConsensusClient.Value}}{{end}}
+      - NETWORK={{.Smartnode.Network}}
+      - EC_CLIENT={{if .ExecutionClientLocal}}{{.ExecutionClient}}{{else}}X{{end}}
+      - CC_CLIENT={{if .ConsensusClientLocal}}{{.ConsensusClient}}{{else}}{{.ExternalConsensusClient}}{{end}}
       - EC_HTTP_ENDPOINT={{.GetEcHttpEndpoint}}
       - EC_WS_ENDPOINT={{.GetEcWsEndpoint}}
-      - EC_ENGINE_ENDPOINT=http://{{.GetExecutionHostname}}:{{.ExecutionCommon.EnginePort.Value}}
-      - EC_ENGINE_WS_ENDPOINT=ws://{{.GetExecutionHostname}}:{{.ExecutionCommon.EnginePort.Value}}
+      - EC_ENGINE_ENDPOINT=http://{{.GetExecutionHostname}}:{{.ExecutionCommon.EnginePort}}
+      - EC_ENGINE_WS_ENDPOINT=ws://{{.GetExecutionHostname}}:{{.ExecutionCommon.EnginePort}}
       - CUSTOM_GRAFFITI={{.CustomGraffiti}}
       - ROCKET_POOL_VERSION=v{{.RocketPoolVersion}}
       - BN_P2P_PORT={{$p2p}}
-      - BN_API_PORT={{.ConsensusCommon.ApiPort.Value}}
+      - BN_API_PORT={{.ConsensusCommon.ApiPort}}
       - BN_MAX_PEERS={{.GetBNMaxPeers}}
-      - ENABLE_METRICS={{.EnableMetrics.Value}}
-      - BN_METRICS_PORT={{.BnMetricsPort.Value}}
+      - ENABLE_METRICS={{.EnableMetrics}}
+      - BN_METRICS_PORT={{.BnMetricsPort}}
       - EXTERNAL_IP={{.GetExternalIp}}
-      - CHECKPOINT_SYNC_URL={{.ConsensusCommon.CheckpointSyncProvider.Value}}
+      - CHECKPOINT_SYNC_URL={{.ConsensusCommon.CheckpointSyncProvider}}
       - DOPPELGANGER_DETECTION={{.IsDoppelgangerEnabled}}
       - BN_ADDITIONAL_FLAGS={{.GetBNAdditionalFlags}}
       - FEE_RECIPIENT_FILE={{.FeeRecipientFile}}
-      - ENABLE_BITFLY_NODE_METRICS={{.EnableBitflyNodeMetrics.Value}}
-      - BITFLY_NODE_METRICS_SECRET={{.BitflyNodeMetrics.Secret.Value}}
-      - BITFLY_NODE_METRICS_ENDPOINT={{.BitflyNodeMetrics.Endpoint.Value}}
-      - BITFLY_NODE_METRICS_MACHINE_NAME={{.BitflyNodeMetrics.MachineName.Value}}
+      - ENABLE_BITFLY_NODE_METRICS={{.EnableBitflyNodeMetrics}}
+      - BITFLY_NODE_METRICS_SECRET={{.BitflyNodeMetrics.Secret}}
+      - BITFLY_NODE_METRICS_ENDPOINT={{.BitflyNodeMetrics.Endpoint}}
+      - BITFLY_NODE_METRICS_MACHINE_NAME={{.BitflyNodeMetrics.MachineName}}
       - MEV_BOOST_URL={{.MevBoostUrl}}
       - RETH_ADDRESS={{.Smartnode.GetRethAddress.Hex}}
       - GRAFFITI={{.Graffiti}}
-      - ADDON_GWW_ENABLED={{.GraffitiWallWriter.GetEnabledParameter.Value}}
+      - ADDON_GWW_ENABLED={{.GraffitiWallWriter.GetEnabledParameter}}
       {{- /* Client-specific values */}}
-      {{- if eq .ConsensusClient.Value "teku"}}
-      - TEKU_JVM_HEAP_SIZE={{.Teku.JvmHeapSize.Value}}
-      - TEKU_ARCHIVE_MODE={{.Teku.ArchiveMode.Value}}
-      {{- else if eq .ConsensusClient.Value "prysm"}}
-      - BN_RPC_PORT={{.Prysm.RpcPort.Value}}
-      {{- else if eq .ConsensusClient.Value "nimbus"}}
-      - NIMBUS_PRUNING_MODE={{.Nimbus.PruningMode.Value}}
+      {{- if eq .ConsensusClient.String "teku"}}
+      - TEKU_JVM_HEAP_SIZE={{.Teku.JvmHeapSize}}
+      - TEKU_ARCHIVE_MODE={{.Teku.ArchiveMode}}
+      {{- else if eq .ConsensusClient.String "prysm"}}
+      - BN_RPC_PORT={{.Prysm.RpcPort}}
+      {{- else if eq .ConsensusClient.String "nimbus"}}
+      - NIMBUS_PRUNING_MODE={{.Nimbus.PruningMode}}
       {{- end}}
     entrypoint: sh
     command: "/setup/start-bn.sh"

--- a/install/templates/exporter.tmpl
+++ b/install/templates/exporter.tmpl
@@ -8,14 +8,30 @@
 version: "3.7"
 services:
   node-exporter:
-    image: ${EXPORTER_CONTAINER_TAG}
-    container_name: ${COMPOSE_PROJECT_NAME}_exporter
+    image: {{.Exporter.ContainerTag.Value}}
+    container_name: {{.Smartnode.ProjectName.Value}}_exporter
     cap_drop:
       - ALL
     user: "65534:65534"
     restart: unless-stopped
-    command: [ "--path.procfs=/host/proc", "--path.sysfs=/host/sys", "--collector.textfile.directory=/host/textfile_collector", "--web.listen-address=:${EXPORTER_METRICS_PORT:-9103}"${EXPORTER_ROOTFS_COMMAND}${EXPORTER_ADDITIONAL_FLAGS} ]
-    volumes: [ "/proc:/host/proc:ro,rslave", "/sys:/host/sys:ro,rslave", "/var/lib/node_exporter/textfile_collector:/host/textfile_collector:ro"${EXPORTER_ROOTFS_VOLUME} ]
+    command:
+      - "--path.procfs=/host/proc"
+      - "--path.sysfs=/host/sys"
+      - "--collector.textfile.directory=/host/textfile_collector"
+      - "--web.listen-address=:{{or .ExporterMetricsPort.Value "9103"}}"
+      {{- if .Exporter.RootFs.Value}}
+      - "--path.rootfs=/rootfs"
+      {{- end}}
+      {{- range $flag := .GetExporterAdditionalFlags}}
+      - "{{$flag}}"
+      {{- end}}
+    volumes:
+      - "/proc:/host/proc:ro,rslave"
+      - "/sys:/host/sys:ro,rslave"
+      - "/var/lib/node_exporter/textfile_collector:/host/textfile_collector:ro"
+      {{- if .Exporter.RootFs.Value }}
+      - "/:/rootfs:ro"
+      {{- end}}
     network_mode: host
 networks:
   net:

--- a/install/templates/exporter.tmpl
+++ b/install/templates/exporter.tmpl
@@ -8,8 +8,8 @@
 version: "3.7"
 services:
   node-exporter:
-    image: {{.Exporter.ContainerTag.Value}}
-    container_name: {{.Smartnode.ProjectName.Value}}_exporter
+    image: {{.Exporter.ContainerTag}}
+    container_name: {{.Smartnode.ProjectName}}_exporter
     cap_drop:
       - ALL
     user: "65534:65534"
@@ -19,7 +19,7 @@ services:
       - "--path.sysfs=/host/sys"
       - "--collector.textfile.directory=/host/textfile_collector"
       - "--web.listen-address=:{{or .ExporterMetricsPort.Value "9103"}}"
-      {{- if .Exporter.RootFs.Value}}
+      {{- if .Exporter.RootFs.Value }}
       - "--path.rootfs=/rootfs"
       {{- end}}
       {{- range $flag := .GetExporterAdditionalFlags}}

--- a/install/templates/grafana.tmpl
+++ b/install/templates/grafana.tmpl
@@ -5,18 +5,19 @@
 # See https://docs.docker.com/compose/extends/#adding-and-overriding-configuration
 # for more information on overriding specific parameters of docker-compose files.
 
+{{$port := (or .Grafana.Port.Value 3100) -}}
 version: "3.7"
 services:
   grafana:
-    image: ${GRAFANA_CONTAINER_TAG}
-    container_name: ${COMPOSE_PROJECT_NAME}_grafana
+    image: {{.Grafana.ContainerTag.Value}}
+    container_name: {{.Smartnode.ProjectName.Value}}_grafana
     restart: unless-stopped
     environment:
-      - GF_SERVER_HTTP_PORT=${GRAFANA_PORT:-3100}
+      - GF_SERVER_HTTP_PORT={{$port}}
     ports: 
-      - "${GRAFANA_PORT:-3100}:${GRAFANA_PORT:-3100}/tcp"
+      - "{{$port}}:{{$port}}/tcp"
     volumes:
-      - "${ROCKETPOOL_FOLDER}/grafana-prometheus-datasource.yml:/etc/grafana/provisioning/datasources/prometheus.yml"
+      - "{{.RocketPoolDirectory}}/grafana-prometheus-datasource.yml:/etc/grafana/provisioning/datasources/prometheus.yml"
       - "grafana-storage:/var/lib/grafana"
     networks:
       - net

--- a/install/templates/grafana.tmpl
+++ b/install/templates/grafana.tmpl
@@ -9,8 +9,8 @@
 version: "3.7"
 services:
   grafana:
-    image: {{.Grafana.ContainerTag.Value}}
-    container_name: {{.Smartnode.ProjectName.Value}}_grafana
+    image: {{.Grafana.ContainerTag}}
+    container_name: {{.Smartnode.ProjectName}}_grafana
     restart: unless-stopped
     environment:
       - GF_SERVER_HTTP_PORT={{$port}}

--- a/install/templates/mev-boost.tmpl
+++ b/install/templates/mev-boost.tmpl
@@ -8,18 +8,18 @@
 version: "3.7"
 services:
   mev-boost:
-    image: ${MEV_BOOST_CONTAINER_TAG}
-    container_name: ${COMPOSE_PROJECT_NAME}_mev-boost
+    image: {{.MevBoost.ContainerTag.Value}}
+    container_name: {{.Smartnode.ProjectName.Value}}_mev-boost
     restart: unless-stopped
-    ports: [${MEV_BOOST_OPEN_API_PORT}]
+    ports: [{{.GetMevBoostOpenPorts}}]
     volumes:
-      - ${ROCKETPOOL_FOLDER}/scripts:/setup:ro
+      - {{.RocketPoolDirectory}}/scripts:/setup:ro
     networks:
       - net
     environment:
-      - NETWORK=${NETWORK}
-      - MEV_BOOST_PORT=${MEV_BOOST_PORT}
-      - MEV_BOOST_RELAYS=${MEV_BOOST_RELAYS}
+      - NETWORK={{.Smartnode.Network.Value}}
+      - MEV_BOOST_PORT={{.MevBoost.Port.Value}}
+      - MEV_BOOST_RELAYS={{.MevBoost.GetRelayString}}
     entrypoint: sh
     command: "/setup/start-mev-boost.sh"
     cap_drop:

--- a/install/templates/mev-boost.tmpl
+++ b/install/templates/mev-boost.tmpl
@@ -8,8 +8,8 @@
 version: "3.7"
 services:
   mev-boost:
-    image: {{.MevBoost.ContainerTag.Value}}
-    container_name: {{.Smartnode.ProjectName.Value}}_mev-boost
+    image: {{.MevBoost.ContainerTag}}
+    container_name: {{.Smartnode.ProjectName}}_mev-boost
     restart: unless-stopped
     ports: [{{.GetMevBoostOpenPorts}}]
     volumes:
@@ -17,8 +17,8 @@ services:
     networks:
       - net
     environment:
-      - NETWORK={{.Smartnode.Network.Value}}
-      - MEV_BOOST_PORT={{.MevBoost.Port.Value}}
+      - NETWORK={{.Smartnode.Network}}
+      - MEV_BOOST_PORT={{.MevBoost.Port}}
       - MEV_BOOST_RELAYS={{.MevBoost.GetRelayString}}
     entrypoint: sh
     command: "/setup/start-mev-boost.sh"

--- a/install/templates/node.tmpl
+++ b/install/templates/node.tmpl
@@ -9,12 +9,12 @@ version: "3.7"
 services:
   node:
     image: {{.Smartnode.GetSmartnodeContainerTag}}
-    container_name: {{.Smartnode.ProjectName.Value}}_node
+    container_name: {{.Smartnode.ProjectName}}_node
     restart: unless-stopped
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - {{.RocketPoolDirectory}}:/.rocketpool
-      - {{.Smartnode.DataPath.Value}}:/.rocketpool/data
+      - {{.Smartnode.DataPath}}:/.rocketpool/data
     networks:
       - net
     command: "-m 0.0.0.0 -r {{or .NodeMetricsPort.Value "9102"}} node"

--- a/install/templates/node.tmpl
+++ b/install/templates/node.tmpl
@@ -8,16 +8,16 @@
 version: "3.7"
 services:
   node:
-    image: ${SMARTNODE_IMAGE}
-    container_name: ${COMPOSE_PROJECT_NAME}_node
+    image: {{.Smartnode.GetSmartnodeContainerTag}}
+    container_name: {{.Smartnode.ProjectName.Value}}_node
     restart: unless-stopped
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
-      - ${ROCKETPOOL_FOLDER}:/.rocketpool
-      - ${ROCKETPOOL_DATA_FOLDER}:/.rocketpool/data
+      - {{.RocketPoolDirectory}}:/.rocketpool
+      - {{.Smartnode.DataPath.Value}}:/.rocketpool/data
     networks:
       - net
-    command: "-m 0.0.0.0 -r ${NODE_METRICS_PORT:-9102} node"
+    command: "-m 0.0.0.0 -r {{or .NodeMetricsPort.Value "9102"}} node"
     cap_drop:
       - all
     cap_add:

--- a/install/templates/prometheus.tmpl
+++ b/install/templates/prometheus.tmpl
@@ -8,8 +8,8 @@
 version: "3.7"
 services:
   prometheus:
-    image: {{.Prometheus.ContainerTag.Value}}
-    container_name: {{.Smartnode.ProjectName.Value}}_prometheus
+    image: {{.Prometheus.ContainerTag}}
+    container_name: {{.Smartnode.ProjectName}}_prometheus
     restart: unless-stopped
     command:
       - "--web.listen-address=:{{or .Prometheus.Port.Value "9091"}}"

--- a/install/templates/prometheus.tmpl
+++ b/install/templates/prometheus.tmpl
@@ -8,14 +8,19 @@
 version: "3.7"
 services:
   prometheus:
-    image: ${PROMETHEUS_CONTAINER_TAG}
-    container_name: ${COMPOSE_PROJECT_NAME}_prometheus
+    image: {{.Prometheus.ContainerTag.Value}}
+    container_name: {{.Smartnode.ProjectName.Value}}_prometheus
     restart: unless-stopped
-    command: [ "--web.listen-address=:${PROMETHEUS_PORT:-9091}", "--config.file=/etc/prometheus/prometheus.yml"${PROMETHEUS_ADDITIONAL_FLAGS} ]
-    ports: [${PROMETHEUS_OPEN_PORTS}]
+    command:
+      - "--web.listen-address=:{{or .Prometheus.Port.Value "9091"}}"
+      - "--config.file=/etc/prometheus/prometheus.yml"
+      {{- range $flag := .GetPrometheusAdditionalFlags}}
+      - "{{$flag}}"
+      {{- end}}
+    ports: [{{.GetPrometheusOpenPorts}}]
     volumes:
-      - "${ROCKETPOOL_FOLDER}/prometheus.yml:/etc/prometheus/prometheus.yml"
-      - "${ROCKETPOOL_FOLDER}/extra-scrape-jobs:/extra-scrape-jobs"
+      - "{{.RocketPoolDirectory}}/prometheus.yml:/etc/prometheus/prometheus.yml"
+      - "{{.RocketPoolDirectory}}/extra-scrape-jobs:/extra-scrape-jobs"
       - "prometheus-data:/prometheus"
     networks:
       - net

--- a/install/templates/validator.tmpl
+++ b/install/templates/validator.tmpl
@@ -10,38 +10,38 @@ services:
   validator:
     image: {{.GetVCContainerTag}}
     user: root
-    container_name: {{.Smartnode.ProjectName.Value}}_validator
+    container_name: {{.Smartnode.ProjectName}}_validator
     restart: unless-stopped
     stop_grace_period: 3m
     volumes:
-      - {{.Smartnode.DataPath.Value}}/validators:/validators
+      - {{.Smartnode.DataPath}}/validators:/validators
       - {{.RocketPoolDirectory}}/scripts:/setup:ro
       - {{.RocketPoolDirectory}}/addons:/addons
     networks:
       - net
     environment:
-      - NETWORK={{.Smartnode.Network.Value}}
-      - EC_CLIENT={{if .ExecutionClientLocal}}{{.ExecutionClient.Value}}{{else}}X{{end}}
-      - CC_CLIENT={{if .ConsensusClientLocal}}{{.ConsensusClient.Value}}{{else}}{{.ExternalConsensusClient.Value}}{{end}}
+      - NETWORK={{.Smartnode.Network}}
+      - EC_CLIENT={{if .ExecutionClientLocal}}{{.ExecutionClient}}{{else}}X{{end}}
+      - CC_CLIENT={{if .ConsensusClientLocal}}{{.ConsensusClient}}{{else}}{{.ExternalConsensusClient}}{{end}}
       - CC_API_ENDPOINT={{.ConsensusClientApiUrl}}
       - CC_RPC_ENDPOINT={{.ConsensusClientRpcUrl}}
       - FALLBACK_CC_API_ENDPOINT={{.FallbackCcApiUrl}}
       - FALLBACK_CC_RPC_ENDPOINT={{.FallbackCcRpcUrl}}
       - CUSTOM_GRAFFITI={{.CustomGraffiti}}
       - ROCKET_POOL_VERSION=v{{.RocketPoolVersion}}
-      - ENABLE_METRICS={{.EnableMetrics.Value}}
-      - VC_METRICS_PORT={{.VcMetricsPort.Value}}
+      - ENABLE_METRICS={{.EnableMetrics}}
+      - VC_METRICS_PORT={{.VcMetricsPort}}
       - DOPPELGANGER_DETECTION={{.IsDoppelgangerEnabled}}
       - VC_ADDITIONAL_FLAGS={{.VcAdditionalFlags}}
       - FEE_RECIPIENT_FILE={{.FeeRecipientFile}}
-      - ENABLE_BITFLY_NODE_METRICS={{.EnableBitflyNodeMetrics.Value}}
-      - BITFLY_NODE_METRICS_SECRET={{.BitflyNodeMetrics.Secret.Value}}
-      - BITFLY_NODE_METRICS_ENDPOINT={{.BitflyNodeMetrics.Endpoint.Value}}
-      - BITFLY_NODE_METRICS_MACHINE_NAME={{.BitflyNodeMetrics.MachineName.Value}}
+      - ENABLE_BITFLY_NODE_METRICS={{.EnableBitflyNodeMetrics}}
+      - BITFLY_NODE_METRICS_SECRET={{.BitflyNodeMetrics.Secret}}
+      - BITFLY_NODE_METRICS_ENDPOINT={{.BitflyNodeMetrics.Endpoint}}
+      - BITFLY_NODE_METRICS_MACHINE_NAME={{.BitflyNodeMetrics.MachineName}}
       - GRAFFITI={{.Graffiti}}
-      - ADDON_GWW_ENABLED={{.GraffitiWallWriter.GetEnabledParameter.Value}}
+      - ADDON_GWW_ENABLED={{.GraffitiWallWriter.GetEnabledParameter}}
       - MEV_BOOST_URL={{.MevBoostUrl}}
-      - ENABLE_MEV_BOOST={{.EnableMevBoost.Value}}
+      - ENABLE_MEV_BOOST={{.EnableMevBoost}}
     entrypoint: sh
     command: "/setup/start-vc.sh"
     cap_drop:

--- a/install/templates/validator.tmpl
+++ b/install/templates/validator.tmpl
@@ -8,41 +8,40 @@
 version: "3.7"
 services:
   validator:
-    image: ${VC_CONTAINER_TAG}
+    image: {{.GetVCContainerTag}}
     user: root
-    container_name: ${COMPOSE_PROJECT_NAME}_validator
+    container_name: {{.Smartnode.ProjectName.Value}}_validator
     restart: unless-stopped
     stop_grace_period: 3m
     volumes:
-      - ${ROCKETPOOL_DATA_FOLDER}/validators:/validators
-      - ${ROCKETPOOL_FOLDER}/scripts:/setup:ro
-      - ${ROCKETPOOL_FOLDER}/addons:/addons
+      - {{.Smartnode.DataPath.Value}}/validators:/validators
+      - {{.RocketPoolDirectory}}/scripts:/setup:ro
+      - {{.RocketPoolDirectory}}/addons:/addons
     networks:
       - net
     environment:
-      - NETWORK=${NETWORK}
-      - EC_CLIENT=${EC_CLIENT}
-      - CC_CLIENT=${CC_CLIENT}
-      - CC_API_ENDPOINT=${CC_API_ENDPOINT}
-      - CC_RPC_ENDPOINT=${CC_RPC_ENDPOINT}
-      - FALLBACK_CC_API_ENDPOINT=${FALLBACK_CC_API_ENDPOINT}
-      - FALLBACK_CC_RPC_ENDPOINT=${FALLBACK_CC_RPC_ENDPOINT}
-      - CUSTOM_GRAFFITI=${CUSTOM_GRAFFITI}
-      - ROCKET_POOL_VERSION=${ROCKET_POOL_VERSION}
-      - ENABLE_METRICS=${ENABLE_METRICS}
-      - VC_METRICS_PORT=${VC_METRICS_PORT}
-      - DOPPELGANGER_DETECTION=${DOPPELGANGER_DETECTION}
-      - VC_ADDITIONAL_FLAGS=${VC_ADDITIONAL_FLAGS}
-      - NODE_FEE_RECIPIENT=${NODE_FEE_RECIPIENT}
-      - FEE_RECIPIENT_FILE=${FEE_RECIPIENT_FILE}
-      - ENABLE_BITFLY_NODE_METRICS=${ENABLE_BITFLY_NODE_METRICS}
-      - BITFLY_NODE_METRICS_SECRET=${BITFLY_NODE_METRICS_SECRET}
-      - BITFLY_NODE_METRICS_ENDPOINT=${BITFLY_NODE_METRICS_ENDPOINT}
-      - BITFLY_NODE_METRICS_MACHINE_NAME=${BITFLY_NODE_METRICS_MACHINE_NAME}
-      - GRAFFITI=${GRAFFITI}
-      - ADDON_GWW_ENABLED=${ADDON_GWW_ENABLED}
-      - MEV_BOOST_URL=${MEV_BOOST_URL}
-      - ENABLE_MEV_BOOST=${ENABLE_MEV_BOOST}
+      - NETWORK={{.Smartnode.Network.Value}}
+      - EC_CLIENT={{if .ExecutionClientLocal}}{{.ExecutionClient.Value}}{{else}}X{{end}}
+      - CC_CLIENT={{if .ConsensusClientLocal}}{{.ConsensusClient.Value}}{{else}}{{.ExternalConsensusClient.Value}}{{end}}
+      - CC_API_ENDPOINT={{.ConsensusClientApiUrl}}
+      - CC_RPC_ENDPOINT={{.ConsensusClientRpcUrl}}
+      - FALLBACK_CC_API_ENDPOINT={{.FallbackCcApiUrl}}
+      - FALLBACK_CC_RPC_ENDPOINT={{.FallbackCcRpcUrl}}
+      - CUSTOM_GRAFFITI={{.CustomGraffiti}}
+      - ROCKET_POOL_VERSION=v{{.RocketPoolVersion}}
+      - ENABLE_METRICS={{.EnableMetrics.Value}}
+      - VC_METRICS_PORT={{.VcMetricsPort.Value}}
+      - DOPPELGANGER_DETECTION={{.IsDoppelgangerEnabled}}
+      - VC_ADDITIONAL_FLAGS={{.VcAdditionalFlags}}
+      - FEE_RECIPIENT_FILE={{.FeeRecipientFile}}
+      - ENABLE_BITFLY_NODE_METRICS={{.EnableBitflyNodeMetrics.Value}}
+      - BITFLY_NODE_METRICS_SECRET={{.BitflyNodeMetrics.Secret.Value}}
+      - BITFLY_NODE_METRICS_ENDPOINT={{.BitflyNodeMetrics.Endpoint.Value}}
+      - BITFLY_NODE_METRICS_MACHINE_NAME={{.BitflyNodeMetrics.MachineName.Value}}
+      - GRAFFITI={{.Graffiti}}
+      - ADDON_GWW_ENABLED={{.GraffitiWallWriter.GetEnabledParameter.Value}}
+      - MEV_BOOST_URL={{.MevBoostUrl}}
+      - ENABLE_MEV_BOOST={{.EnableMevBoost.Value}}
     entrypoint: sh
     command: "/setup/start-vc.sh"
     cap_drop:

--- a/install/templates/watchtower.tmpl
+++ b/install/templates/watchtower.tmpl
@@ -9,11 +9,11 @@ version: "3.7"
 services:
   watchtower:
     image: {{.Smartnode.GetSmartnodeContainerTag}}
-    container_name: {{.Smartnode.ProjectName.Value}}_watchtower
+    container_name: {{.Smartnode.ProjectName}}_watchtower
     restart: unless-stopped
     volumes:
       - {{.RocketPoolDirectory}}:/.rocketpool
-      - {{.Smartnode.DataPath.Value}}:/.rocketpool/data
+      - {{.Smartnode.DataPath}}:/.rocketpool/data
     networks:
       - net
     command: "-m 0.0.0.0 -r {{or .WatchtowerMetricsPort.Value "9104"}} watchtower"

--- a/install/templates/watchtower.tmpl
+++ b/install/templates/watchtower.tmpl
@@ -8,15 +8,15 @@
 version: "3.7"
 services:
   watchtower:
-    image: ${SMARTNODE_IMAGE}
-    container_name: ${COMPOSE_PROJECT_NAME}_watchtower
+    image: {{.Smartnode.GetSmartnodeContainerTag}}
+    container_name: {{.Smartnode.ProjectName.Value}}_watchtower
     restart: unless-stopped
     volumes:
-      - ${ROCKETPOOL_FOLDER}:/.rocketpool
-      - ${ROCKETPOOL_DATA_FOLDER}:/.rocketpool/data
+      - {{.RocketPoolDirectory}}:/.rocketpool
+      - {{.Smartnode.DataPath.Value}}:/.rocketpool/data
     networks:
       - net
-    command: "-m 0.0.0.0 -r ${WATCHTOWER_METRICS_PORT:-9104} watchtower"
+    command: "-m 0.0.0.0 -r {{or .WatchtowerMetricsPort.Value "9104"}} watchtower"
     cap_drop:
       - all
     cap_add:


### PR DESCRIPTION
So, the syntax here is two phrases.

First, `(index . "FOO")` when passed a `settings map[string]string` is the same as `settings["FOO"]`

Second, `or x y` is the same as `x ? x  : y`

Combining them gives us the defaulting behavior we had with envsubst.

In a future change, I suggest we move away from using `map[string]string` and instead just pass the config struct to the template engine. Then we can write variables such as `{{or .Execution.ApiPortNumber "8545"}}` which is a bit more readable.