### PR TITLE
Fix eth1 metrics for externally managed execution clients

### DIFF
--- a/install/prometheus.tmpl
+++ b/install/prometheus.tmpl
@@ -16,12 +16,14 @@ scrape_configs:
       # We have to use 'hosts.docker.internal' to refer to it due to this configuration
       - targets: ['host.docker.internal:{{or .ExporterMetricsPort.Value "9103"}}']
 
-  - job_name: '{{if (eq .ExecutionClient.String "geth")}}geth{{else}}eth1{{end}}'
+  - job_name: 'geth'
     static_configs:
       - targets: ['{{.GetExecutionHostname}}:{{or .EcMetricsPort.Value "9105"}}']
-    {{- if (eq .ExecutionClient.String "geth")}}
     metrics_path: /debug/metrics/prometheus
-    {{- end}}
+
+  - job_name: 'eth1'
+    static_configs:
+      - targets: ['{{.GetExecutionHostname}}:{{or .EcMetricsPort.Value "9105"}}']
 
   - job_name: 'eth2'
     static_configs:


### PR DESCRIPTION
The short version is, when a client is externally managed, we don't know if it's geth or not-geth.

Therefore, we should keep both jobs active. If we want to be 'perfectly nice' to prometheus we can do something like:
```
if externally managed:
  two templates
else:
  one template
```
in the template body, but it seems more complex that just letting prom fail on one job.