### PR TITLE
Add JWT secret creation in Reth EC startup

### DIFF
--- a/install/scripts/start-ec.sh
+++ b/install/scripts/start-ec.sh
@@ -292,6 +292,11 @@ fi
 # Reth startup
 if [ "$CLIENT" = "reth" ]; then
 
+    # Create the JWT secret
+    if [ ! -f "/secrets/jwtsecret" ]; then
+        openssl rand -hex 32 | tr -d "\n" > /secrets/jwtsecret
+    fi
+
     CMD="$PERF_PREFIX /usr/local/bin/reth node $RETH_NETWORK \
         --datadir /ethclient/reth \
         --http \


### PR DESCRIPTION
Hey, just a small PR to add JWT secret creation if the file doesn't exist (like on others Execution Clients) for Reth.

Ran into this error from a fresh node otherwise:
```
rocketpool_eth1        | 2024-03-05T22:18:45.183876Z  INFO reth 0.1.0-alpha.20 (54db85a) starting
rocketpool_eth1        | 2024-03-05T22:18:45.184515Z  INFO Opening database path="/ethclient/reth/db"
rocketpool_eth1        | 2024-03-05T22:18:45.188216Z  INFO Database opened
rocketpool_eth1        | 2024-03-05T22:18:45.188494Z  INFO Configuration loaded path="/ethclient/reth/reth.toml"
rocketpool_eth1        | 2024-03-05T22:18:45.188723Z  INFO Starting metrics endpoint addr=0.0.0.0:9105
rocketpool_eth1        | 2024-03-05T22:18:45.188934Z  INFO Pre-merge hard forks (block based):
rocketpool_eth1        | - Frontier                         @0
rocketpool_eth1        | - Homestead                        @0
rocketpool_eth1        | - Dao                              @0
rocketpool_eth1        | - Tangerine                        @0
rocketpool_eth1        | - SpuriousDragon                   @0
rocketpool_eth1        | - Byzantium                        @0
rocketpool_eth1        | - Constantinople                   @0
rocketpool_eth1        | - Petersburg                       @0
rocketpool_eth1        | - Istanbul                         @0
rocketpool_eth1        | - MuirGlacier                      @0
rocketpool_eth1        | - Berlin                           @0
rocketpool_eth1        | - London                           @0
rocketpool_eth1        | Merge hard forks:
rocketpool_eth1        | - Paris                            @0 (network is known to be merged)
rocketpool_eth1        |
rocketpool_eth1        | Post-merge hard forks (timestamp based):
rocketpool_eth1        | - Shanghai                         @1696000704
rocketpool_eth1        | - Cancun                           @1707305664
rocketpool_eth1        |
rocketpool_eth1        | 2024-03-05T22:18:45.250910Z  INFO Transaction pool initialized
rocketpool_eth1        | 2024-03-05T22:18:45.251055Z  INFO Connecting to P2P network
rocketpool_eth1        | 2024-03-05T22:18:45.251214Z  INFO Loading saved peers file=/ethclient/reth/known-peers.json
rocketpool_eth1        | 2024-03-05T22:18:45.252549Z  INFO Connected to P2P network peer_id=0x3cfcb9cf0e5076aea38dd5c8295de20fc276bca01cd7743ade8f69ddd7b68127936a268279aeda69d1a4034b976183c6721bbcc1bba90af011201c474db41f2a local_addr=0.0.0.0:30303 enode=enode://3cfcb9cf0e5076aea38dd5c8295de20fc276bca01cd7743ade8f69ddd7b68127936a268279aeda69d1a4034b976183c6721bbcc1bba90af011201c474db41f2a@127.0.0.1:30303
rocketpool_eth1        | 2024-03-05T22:18:45.253279Z  INFO Consensus engine initialized
rocketpool_eth1        | 2024-03-05T22:18:45.253319Z  INFO Engine API handler initialized
rocketpool_eth1        | 2024-03-05T22:18:45.253364Z ERROR shutting down due to error
rocketpool_eth1        | 2024-03-05T22:18:45.253811Z  INFO Wrote network peers to file peers_file="/ethclient/reth/known-peers.json"
rocketpool_eth1        | Error: failed to read from "/secrets/jwtsecret": No such file or directory (os error 2)
rocketpool_eth1        |
rocketpool_eth1        | Caused by:
rocketpool_eth1        |     No such file or directory (os error 2)
rocketpool_eth1        |
rocketpool_eth1        | Location:
rocketpool_eth1        |     /project/bin/reth/src/builder.rs:402:26
rocketpool_eth1 exited with code 1
```

