### PR TITLE
fix: disable discord webhook receiver when webhook url is blank

### DIFF
--- a/install/alerting/alertmanager.tmpl
+++ b/install/alerting/alertmanager.tmpl
@@ -36,13 +36,17 @@ route:
 
 receivers:
   - name: "node_operator_default"
+    {{- if .DiscordWebhookURL.Value }}
     discord_configs:
       - webhook_url: "{{ .DiscordWebhookURL.Value }}"
+    {{- end }}
   
   - name: "node_operator_no_resolved"
+    {{- if .DiscordWebhookURL.Value }}
     discord_configs:
       - webhook_url: "{{ .DiscordWebhookURL.Value }}"
         send_resolved: false
+    {{- end }}
 
 inhibit_rules:
   # Inhibit rules mute a new alert (target) that matches an existing alert (source).


### PR DESCRIPTION
fixes rocket-pool/smartnode#464