### PR TITLE
Add Reth EC metrics in Grafana dashboard

### DIFF
--- a/Dashboards/Rocket Pool Dashboard v1.3.0.json
+++ b/Dashboards/Rocket Pool Dashboard v1.3.0.json
@@ -845,7 +845,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "(system_cpu_procload{job=\"geth\"} / scalar(count without(cpu, mode) (node_cpu_seconds_total{mode=\"idle\"}))) OR # Geth\nirate(process_cpu_seconds_total{job=\"eth1\"}[$__rate_interval]) * 100 / scalar(count without(cpu, mode) (node_cpu_seconds_total{mode=\"idle\"})) # Besu, Nethermind",
+          "expr": "(system_cpu_procload{job=\"geth\"} / scalar(count without(cpu, mode) (node_cpu_seconds_total{mode=\"idle\"}))) OR # Geth\nirate(process_cpu_seconds_total{job=\"eth1\"}[$__rate_interval]) * 100 / scalar(count without(cpu, mode) (node_cpu_seconds_total{mode=\"idle\"})) OR # Besu, Nethermind\nirate(reth_process_cpu_seconds_total{job=\"eth1\"}[$__rate_interval]) * 100 / scalar(count without(cpu, mode) (node_cpu_seconds_total{mode=\"idle\"})) # Reth",
           "hide": false,
           "legendFormat": "EC",
           "range": true,
@@ -979,7 +979,7 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "system_memory_used{job=\"geth\"} OR # Geth\nprocess_resident_memory_bytes{job=\"eth1\"} OR # Besu\nprocess_working_set_bytes{job=\"eth1\"} # Nethermind",
+          "expr": "system_memory_used{job=\"geth\"} OR # Geth\nprocess_resident_memory_bytes{job=\"eth1\"} OR # Besu\nprocess_working_set_bytes{job=\"eth1\"} OR # Nethermind\nreth_process_resident_memory_bytes{job=\"eth1\"} # Reth",
           "interval": "",
           "legendFormat": "EC",
           "range": true,
@@ -1454,7 +1454,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "(system_cpu_procload{job=\"geth\"} / scalar(count without(cpu, mode) (node_cpu_seconds_total{mode=\"idle\"}))) OR # Geth\nirate(process_cpu_seconds_total{job=\"eth1\"}[$__rate_interval]) * 100 / scalar(count without(cpu, mode) (node_cpu_seconds_total{mode=\"idle\"})) # Besu, Nethermind",
+          "expr": "(system_cpu_procload{job=\"geth\"} / scalar(count without(cpu, mode) (node_cpu_seconds_total{mode=\"idle\"}))) OR # Geth\nirate(process_cpu_seconds_total{job=\"eth1\"}[$__rate_interval]) * 100 / scalar(count without(cpu, mode) (node_cpu_seconds_total{mode=\"idle\"})) OR # Besu, Nethermind\nirate(reth_process_cpu_seconds_total{job=\"eth1\"}[$__rate_interval]) * 100 / scalar(count without(cpu, mode) (node_cpu_seconds_total{mode=\"idle\"})) # Reth",
           "hide": false,
           "legendFormat": "EC (Stacked)",
           "range": true,
@@ -1681,7 +1681,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "system_memory_used{job=\"geth\"} OR # Geth\nprocess_resident_memory_bytes{job=\"eth1\"} OR # Besu\nprocess_working_set_bytes{job=\"eth1\"} # Nethermind",
+          "expr": "system_memory_used{job=\"geth\"} OR # Geth\nprocess_resident_memory_bytes{job=\"eth1\"} OR # Besu\nprocess_working_set_bytes{job=\"eth1\"} OR # Nethermind\nreth_process_resident_memory_bytes{job=\"eth1\"} # Reth",
           "hide": false,
           "legendFormat": "EC (Stacked)",
           "range": true,
@@ -1966,7 +1966,7 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "p2p_peers{job=\"geth\"} OR # Geth\nnethermind_sync_peers{job=\"eth1\"} OR # Nethermind\nethereum_peer_count{job=\"eth1\"} # Besu",
+          "expr": "p2p_peers{job=\"geth\"} OR # Geth\nnethermind_sync_peers{job=\"eth1\"} OR # Nethermind\nethereum_peer_count{job=\"eth1\"} OR # Besu\nreth_network_connected_peers{job=\"eth1\"} # Reth",
           "interval": "",
           "legendFormat": "",
           "range": true,
@@ -2159,7 +2159,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "p2p_peers{job=\"geth\"} OR # Geth\nnethermind_sync_peers{job=\"eth1\"} OR # Nethermind\nethereum_peer_count{job=\"eth1\"} # Besu",
+          "expr": "p2p_peers{job=\"geth\"} OR # Geth\nnethermind_sync_peers{job=\"eth1\"} OR # Nethermind\nethereum_peer_count{job=\"eth1\"} OR # Besu\nreth_network_connected_peers{job=\"eth1\"} # Reth",
           "hide": false,
           "legendFormat": "EC",
           "range": true,


### PR DESCRIPTION
Using Reth's official doc metrics page https://paradigmxyz.github.io/reth/run/observability.html, I updated the Grafana dashboard (CPU, RAM & peers).

I kept the current dashboard version as it's a new execution client added (still in beta), but feel free to update it.

Please note that they provide a very detailed dashboard in their Github: https://github.com/paradigmxyz/reth/blob/main/etc/grafana/dashboards/overview.json