### PR TITLE
fix: Fixes invalid "Smartnode Update Available" when OS updates are available

### DIFF
--- a/install/alerting/rules/default.tmpl
+++ b/install/alerting/rules/default.tmpl
@@ -119,7 +119,7 @@ groups:
 
       {{{- if .AlertEnabled_RPUpdatesAvailable.Value }}}
       - alert: RPUpdatesAvailable
-        expr: max(os_upgrades_pending{job="node"}) > 0
+        expr: max(rocketpool_version_update{job="node"}) > 0
         labels:
           severity: warning
           job: node


### PR DESCRIPTION


This was noted in support at https://discord.com/channels/405159462932971535/468923220607762485/1224559939280703610