### PR TITLE
fix: cors header wasn't being set correctly

### DIFF
--- a/install/scripts/start-ec.sh
+++ b/install/scripts/start-ec.sh
@@ -310,7 +310,7 @@ if [ "$CLIENT" = "reth" ]; then
         --http.addr 0.0.0.0 \
         --http.port ${EC_HTTP_PORT:-8545} \
         --http.api eth,net,web3 \
-        --http.corsdomain '*' \
+        --http.corsdomain="*" \
         --ws \
         --ws.addr 0.0.0.0 \
         --ws.port ${EC_WS_PORT:-8546} \


### PR DESCRIPTION
This corrects the behaviour where the origin header wasn't being set correctly.

`access-control-allow-origin: *`