### PR TITLE
Update start-mev-boost.sh to support arbitrary parameter from the AdditionalFlags field.

### DIFF
--- a/install/scripts/start-mev-boost.sh
+++ b/install/scripts/start-mev-boost.sh
@@ -1,5 +1,26 @@
 #!/bin/sh
 
+parse_additional_flags() {
+  # Initialize an empty string for additional arguments
+  ADDITIONAL_ARGS=""
+
+  # Check if the environment variable MEV_BOOST_ADDITIONAL_FLAGS is not empty
+  if [ -n "$MEV_BOOST_ADDITIONAL_FLAGS" ]; then
+    # Split the input string into an array of key-value pairs using comma as the delimiter
+    IFS=',' read -r -a pairs <<< "$MEV_BOOST_ADDITIONAL_FLAGS"
+
+    # Iterate over each key-value pair
+    for pair in "${pairs[@]}"; do
+      # Extract the key and value from the current pair
+      key=$(echo "$pair" | cut -d'=' -f1)
+      value=$(echo "$pair" | cut -d'=' -f2)
+
+      # Append the key-value pair to the ADDITIONAL_ARGS string
+      ADDITIONAL_ARGS="$ADDITIONAL_ARGS -${key} ${value}"
+    done
+  fi
+}
+
 # Set up the network-based flag
 if [ "$NETWORK" = "mainnet" ]; then
     MEV_NETWORK="mainnet"
@@ -10,5 +31,6 @@ else
     exit 1
 fi
 
-# Run MEV-boost
-exec /app/mev-boost -${MEV_NETWORK} -addr 0.0.0.0:${MEV_BOOST_PORT} -relay-check -relays ${MEV_BOOST_RELAYS}
+parse_additional_flags
+
+exec /app/mev-boost -${MEV_NETWORK} -addr 0.0.0.0:${MEV_BOOST_PORT} -relay-check -relays ${MEV_BOOST_RELAYS} ${ADDITIONAL_ARGS}

--- a/install/templates/mev-boost.tmpl
+++ b/install/templates/mev-boost.tmpl
@@ -19,6 +19,7 @@ services:
       - NETWORK={{.Smartnode.Network}}
       - MEV_BOOST_PORT={{.MevBoost.Port}}
       - MEV_BOOST_RELAYS={{.MevBoost.GetRelayString}}
+      - MEV_BOOST_ADDITIONAL_FLAGS={{.MevBoost.AdditionalFlags}}
     entrypoint: sh
     command: "/setup/start-mev-boost.sh"
     cap_drop:


### PR DESCRIPTION
Addressing https://github.com/rocket-pool/smartnode/issues/601

Adding support for arbitrary additional flags to be passed to the start-mev-boost.sh script via MevBoostConfig.