### PR TITLE
Remove monitor-net from prometheus.tmpl

### DIFF
--- a/install/templates/prometheus.tmpl
+++ b/install/templates/prometheus.tmpl
@@ -24,20 +24,9 @@ services:
       - "prometheus-data:/prometheus"
     networks:
       - net
-      - monitor-net
     extra_hosts:
       - "host.docker.internal:host-gateway"
 networks:
-  # Bridge so node-exporter can get the real NIC details
-  # See https://stackoverflow.com/a/66689508 for more info
-  monitor-net:
-    driver: bridge
-    ipam:
-      driver: default
-      config:
-        - subnet: 172.23.0.0/16
-          ip_range: 172.23.5.0/24
-          gateway: 172.23.5.254
   net:
 volumes:
   prometheus-data:


### PR DESCRIPTION
As per https://stackoverflow.com/questions/66676204/prometheus-node-exporter-in-docker-host-networking-vs-hostnames/66689508#66689508 a hard-coded bridge network is not necessary when using `host.docker.internal:host-gateway`

Removing it allows the use of the Grafana stack in environments where other Docker stacks also run, and the hard-coded monitor-net may "step on" existing bridge networks.