### PR TITLE
Fix issue with root mounted as rprivate

### DIFF
--- a/install/templates/exporter.tmpl
+++ b/install/templates/exporter.tmpl
@@ -29,7 +29,7 @@ services:
       - "/sys:/host/sys:ro,rslave"
       - "/var/lib/node_exporter/textfile_collector:/host/textfile_collector:ro"
       {{- if .Exporter.RootFs.Value }}
-      - "/:/rootfs:ro"
+      - "/:/rootfs:ro,rslave"
       {{- end}}
     network_mode: host
 networks:


### PR DESCRIPTION
Fixes an issue with the latest version of docker that prevents smartnode from starting.